### PR TITLE
python: type generated client using Self

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
@@ -15,6 +15,10 @@ import re  # noqa: F401
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 {{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ANY_OF_SCHEMAS = [{{#anyOf}}"{{.}}"{{^-last}}, {{/-last}}{{/anyOf}}]
 
@@ -97,13 +101,13 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> {{{classname}}}:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> {{{classname}}}:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = {{{classname}}}.model_construct()
+        instance = cls.model_construct()
         {{#isNullable}}
         if json_str is None:
             return instance

--- a/modules/openapi-generator/src/main/resources/python/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_enum.mustache
@@ -5,6 +5,10 @@ from aenum import Enum, no_arg
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
 {{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
@@ -21,9 +25,9 @@ class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
     {{/enumVars}}
 
     @classmethod
-    def from_json(cls, json_str: str) -> {{{classname}}}:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of {{classname}} from a JSON string"""
-        return {{classname}}(json.loads(json_str))
+        return cls(json.loads(json_str))
 
     {{#defaultValue}}
 

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -12,6 +12,11 @@ import json
 {{#vendorExtensions.x-py-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-model-imports}}
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}):
     """
@@ -119,7 +124,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> {{^hasChildren}}{{{classname}}}{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union({{#children}}{{{classname}}}{{^-last}}, {{/-last}}{{/children}}){{/discriminator}}{{^discriminator}}{{{classname}}}{{/discriminator}}{{/hasChildren}}:
+    def from_json(cls, json_str: str) -> {{^hasChildren}}Self{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union[{{#children}}Self{{^-last}}, {{/-last}}{{/children}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}{{/hasChildren}}:
         """Create an instance of {{{classname}}} from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -221,7 +226,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> {{^hasChildren}}{{{classname}}}{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union({{#children}}{{{classname}}}{{^-last}}, {{/-last}}{{/children}}){{/discriminator}}{{^discriminator}}{{{classname}}}{{/discriminator}}{{/hasChildren}}:
+    def from_dict(cls, obj: dict) -> {{^hasChildren}}Self{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union[{{#children}}Self{{^-last}}, {{/-last}}{{/children}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}{{/hasChildren}}:
         """Create an instance of {{{classname}}} from a dict"""
         {{#hasChildren}}
         {{#discriminator}}
@@ -241,18 +246,19 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             return None
 
         if not isinstance(obj, dict):
-            return {{{classname}}}.model_validate(obj)
+            return cls.model_validate(obj)
 
         {{#disallowAdditionalPropertiesIfNotPresent}}
         {{^isAdditionalPropertiesTrue}}
         # raise errors for additional fields in the input
+        properties = cls.model_json_schema()["properties"]
         for _key in obj.keys():
-            if _key not in cls.__properties:
+            if _key not in properties:
                 raise ValueError("Error due to additional fields (not defined in {{classname}}) in the input: " + obj)
 
         {{/isAdditionalPropertiesTrue}}
         {{/disallowAdditionalPropertiesIfNotPresent}}
-        _obj = {{{classname}}}.model_validate({
+        _obj = cls.model_validate({
             {{#allVars}}
             {{#isContainer}}
             {{#isArray}}

--- a/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
@@ -15,6 +15,10 @@ import re  # noqa: F401
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 {{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ONE_OF_SCHEMAS = [{{#oneOf}}"{{.}}"{{^-last}}, {{/-last}}{{/oneOf}}]
 
@@ -97,13 +101,13 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> {{{classname}}}:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> {{{classname}}}:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = {{{classname}}}.model_construct()
+        instance = cls.model_construct()
         {{#isNullable}}
         if json_str is None:
             return instance

--- a/samples/client/echo_api/python/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python/openapi_client/models/bird.py
@@ -21,6 +21,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Bird(BaseModel):
     """
@@ -46,7 +51,7 @@ class Bird(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Bird:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Bird from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class Bird(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Bird:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Bird from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Bird.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Bird.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "color": obj.get("color")
         })

--- a/samples/client/echo_api/python/openapi_client/models/category.py
+++ b/samples/client/echo_api/python/openapi_client/models/category.py
@@ -21,6 +21,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Category(BaseModel):
     """
@@ -46,7 +51,7 @@ class Category(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Category:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Category from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Category:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Category.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Category.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name")
         })

--- a/samples/client/echo_api/python/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python/openapi_client/models/data_query.py
@@ -23,6 +23,11 @@ from typing import Optional
 from pydantic import StrictStr
 from pydantic import Field
 from openapi_client.models.query import Query
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DataQuery(Query):
     """
@@ -49,7 +54,7 @@ class DataQuery(Query):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DataQuery:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DataQuery from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -62,15 +67,15 @@ class DataQuery(Query):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DataQuery:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DataQuery from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DataQuery.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DataQuery.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "outcomes": obj.get("outcomes"),
             "suffix": obj.get("suffix"),

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -22,6 +22,11 @@ import json
 from typing import List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from openapi_client.models.string_enum_ref import StringEnumRef
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DefaultValue(BaseModel):
     """
@@ -64,7 +69,7 @@ class DefaultValue(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DefaultValue:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DefaultValue from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -92,15 +97,15 @@ class DefaultValue(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DefaultValue:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DefaultValue from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DefaultValue.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DefaultValue.model_validate({
+        _obj = cls.model_validate({
             "array_string_enum_ref_default": obj.get("array_string_enum_ref_default"),
             "array_string_enum_default": obj.get("array_string_enum_default"),
             "array_string_default": obj.get("array_string_default"),

--- a/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
@@ -23,6 +23,11 @@ from typing import Optional, Union
 from pydantic import BaseModel, StrictFloat, StrictInt
 from pydantic import Field
 from typing_extensions import Annotated
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NumberPropertiesOnly(BaseModel):
     """
@@ -48,7 +53,7 @@ class NumberPropertiesOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NumberPropertiesOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NumberPropertiesOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class NumberPropertiesOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NumberPropertiesOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NumberPropertiesOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NumberPropertiesOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NumberPropertiesOnly.model_validate({
+        _obj = cls.model_validate({
             "number": obj.get("number"),
             "double": obj.get("double")
         })

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -24,6 +24,11 @@ from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from openapi_client.models.category import Category
 from openapi_client.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Pet(BaseModel):
     """
@@ -63,7 +68,7 @@ class Pet(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Pet:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Pet from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -86,15 +91,15 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Pet:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Pet.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Pet.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name"),
             "category": Category.from_dict(obj.get("category")) if obj.get("category") is not None else None,

--- a/samples/client/echo_api/python/openapi_client/models/query.py
+++ b/samples/client/echo_api/python/openapi_client/models/query.py
@@ -22,6 +22,11 @@ import json
 from typing import List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Query(BaseModel):
     """
@@ -58,7 +63,7 @@ class Query(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Query:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Query from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -71,7 +76,7 @@ class Query(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Query:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Query from a dict"""
 
 

--- a/samples/client/echo_api/python/openapi_client/models/string_enum_ref.py
+++ b/samples/client/echo_api/python/openapi_client/models/string_enum_ref.py
@@ -20,6 +20,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class StringEnumRef(str, Enum):
@@ -35,8 +39,8 @@ class StringEnumRef(str, Enum):
     UNCLASSIFIED = 'unclassified'
 
     @classmethod
-    def from_json(cls, json_str: str) -> StringEnumRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of StringEnumRef from a JSON string"""
-        return StringEnumRef(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/client/echo_api/python/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python/openapi_client/models/tag.py
@@ -21,6 +21,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Tag(BaseModel):
     """
@@ -46,7 +51,7 @@ class Tag(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Tag:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Tag from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Tag:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Tag.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Tag.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name")
         })

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -21,6 +21,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseModel):
     """
@@ -48,7 +53,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "color": obj.get("color"),
             "id": obj.get("id"),

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -21,6 +21,11 @@ import json
 
 from typing import List, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
     """
@@ -45,7 +50,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.model_validate({
+        _obj = cls.model_validate({
             "values": obj.get("values")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesAnyType(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesAnyType(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesAnyType:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesAnyType from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class AdditionalPropertiesAnyType(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesAnyType:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesAnyType from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesAnyType.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesAnyType.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesClass(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class AdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesClass.model_validate({
+        _obj = cls.model_validate({
             "map_property": obj.get("map_property"),
             "map_of_map_property": obj.get("map_of_map_property")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesObject(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesObject(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesObject:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesObject from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class AdditionalPropertiesObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesObject:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesObject from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesObject.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesObject.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesWithDescriptionOnly(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesWithDescriptionOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesWithDescriptionOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesWithDescriptionOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesWithDescriptionOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesWithDescriptionOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesWithDescriptionOnly.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -22,6 +22,11 @@ from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.single_ref_type import SingleRefType
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AllOfWithSingleRef(BaseModel):
     """
@@ -47,7 +52,7 @@ class AllOfWithSingleRef(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AllOfWithSingleRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AllOfWithSingleRef from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -60,15 +65,15 @@ class AllOfWithSingleRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AllOfWithSingleRef:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AllOfWithSingleRef from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AllOfWithSingleRef.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AllOfWithSingleRef.model_validate({
+        _obj = cls.model_validate({
             "username": obj.get("username"),
             "SingleRefType": obj.get("SingleRefType")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional, Union
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Animal(BaseModel):
     """
@@ -64,7 +69,7 @@ class Animal(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Union(Cat, Dog):
+    def from_json(cls, json_str: str) -> Union[Self, Self]:
         """Create an instance of Animal from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -77,7 +82,7 @@ class Animal(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Union(Cat, Dog):
+    def from_dict(cls, obj: dict) -> Union[Self, Self]:
         """Create an instance of Animal from a dict"""
         # look up the object type based on discriminator mapping
         object_type = cls.get_discriminator_value(obj)

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
@@ -25,6 +25,10 @@ from typing_extensions import Annotated
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 ANYOFCOLOR_ANY_OF_SCHEMAS = ["List[int]", "str"]
 
@@ -88,13 +92,13 @@ class AnyOfColor(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AnyOfColor:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> AnyOfColor:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = AnyOfColor.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         # deserialize data into List[int]
         try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
@@ -25,6 +25,10 @@ from petstore_api.models.danish_pig import DanishPig
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 ANYOFPIG_ANY_OF_SCHEMAS = ["BasquePig", "DanishPig"]
 
@@ -80,13 +84,13 @@ class AnyOfPig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AnyOfPig:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> AnyOfPig:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = AnyOfPig.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         # anyof_schema_1_validator: Optional[BasquePig] = None
         try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ApiResponse(BaseModel):
     """
@@ -46,7 +51,7 @@ class ApiResponse(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ApiResponse:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ApiResponse from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class ApiResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ApiResponse:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ApiResponse from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ApiResponse.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ApiResponse.model_validate({
+        _obj = cls.model_validate({
             "code": obj.get("code"),
             "type": obj.get("type"),
             "message": obj.get("message")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -21,6 +21,11 @@ import json
 from typing import List, Optional
 from pydantic import BaseModel
 from petstore_api.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayOfArrayOfModel(BaseModel):
     """
@@ -45,7 +50,7 @@ class ArrayOfArrayOfModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayOfArrayOfModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayOfArrayOfModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -67,15 +72,15 @@ class ArrayOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayOfArrayOfModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayOfArrayOfModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayOfArrayOfModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayOfArrayOfModel.model_validate({
+        _obj = cls.model_validate({
             "another_property": [
                     [Tag.from_dict(_inner_item) for _inner_item in _item]
                     for _item in obj.get("another_property")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -21,6 +21,11 @@ import json
 from typing import List, Optional
 from pydantic import BaseModel
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayOfArrayOfNumberOnly(BaseModel):
     """
@@ -45,7 +50,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayOfArrayOfNumberOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayOfArrayOfNumberOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayOfArrayOfNumberOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayOfArrayOfNumberOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayOfArrayOfNumberOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayOfArrayOfNumberOnly.model_validate({
+        _obj = cls.model_validate({
             "ArrayArrayNumber": obj.get("ArrayArrayNumber")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
@@ -21,6 +21,11 @@ import json
 from typing import List, Optional
 from pydantic import BaseModel
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayOfNumberOnly(BaseModel):
     """
@@ -45,7 +50,7 @@ class ArrayOfNumberOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayOfNumberOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayOfNumberOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class ArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayOfNumberOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayOfNumberOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayOfNumberOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayOfNumberOnly.model_validate({
+        _obj = cls.model_validate({
             "ArrayNumber": obj.get("ArrayNumber")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -23,6 +23,11 @@ from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.read_only_first import ReadOnlyFirst
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayTest(BaseModel):
     """
@@ -49,7 +54,7 @@ class ArrayTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -71,15 +76,15 @@ class ArrayTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayTest.model_validate({
+        _obj = cls.model_validate({
             "array_of_string": obj.get("array_of_string"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
@@ -21,6 +21,11 @@ import json
 
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class BasquePig(BaseModel):
     """
@@ -46,7 +51,7 @@ class BasquePig(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> BasquePig:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of BasquePig from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class BasquePig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> BasquePig:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of BasquePig from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return BasquePig.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = BasquePig.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "color": obj.get("color")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Capitalization(BaseModel):
     """
@@ -50,7 +55,7 @@ class Capitalization(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Capitalization:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Capitalization from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -63,15 +68,15 @@ class Capitalization(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Capitalization:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Capitalization from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Capitalization.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Capitalization.model_validate({
+        _obj = cls.model_validate({
             "smallCamel": obj.get("smallCamel"),
             "CapitalCamel": obj.get("CapitalCamel"),
             "small_Snake": obj.get("small_Snake"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import StrictBool
 from petstore_api.models.animal import Animal
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Cat(Animal):
     """
@@ -45,7 +50,7 @@ class Cat(Animal):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Cat:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Cat from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class Cat(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Cat:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Cat from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Cat.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Cat.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "color": obj.get("color") if obj.get("color") is not None else 'red',
             "declawed": obj.get("declawed")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Category(BaseModel):
     """
@@ -45,7 +50,7 @@ class Category(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Category:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Category from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Category:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Category.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Category.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name") if obj.get("name") is not None else 'default-name'
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class CircularReferenceModel(BaseModel):
     """
@@ -45,7 +50,7 @@ class CircularReferenceModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> CircularReferenceModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of CircularReferenceModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class CircularReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> CircularReferenceModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of CircularReferenceModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return CircularReferenceModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = CircularReferenceModel.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "nested": FirstRef.from_dict(obj.get("nested")) if obj.get("nested") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ClassModel(BaseModel):
     """
@@ -45,7 +50,7 @@ class ClassModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ClassModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ClassModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class ClassModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ClassModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ClassModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ClassModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ClassModel.model_validate({
+        _obj = cls.model_validate({
             "_class": obj.get("_class")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Client(BaseModel):
     """
@@ -44,7 +49,7 @@ class Client(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Client:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Client from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -57,15 +62,15 @@ class Client(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Client:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Client from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Client.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Client.model_validate({
+        _obj = cls.model_validate({
             "client": obj.get("client")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
@@ -25,6 +25,10 @@ from typing_extensions import Annotated
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 COLOR_ONE_OF_SCHEMAS = ["List[int]", "str"]
 
@@ -92,13 +96,13 @@ class Color(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Color:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> Color:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = Color.model_construct()
+        instance = cls.model_construct()
         if json_str is None:
             return instance
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -21,6 +21,11 @@ import json
 
 from pydantic import BaseModel, StrictStr
 from petstore_api.models.creature_info import CreatureInfo
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Creature(BaseModel):
     """
@@ -46,7 +51,7 @@ class Creature(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Creature:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Creature from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -62,15 +67,15 @@ class Creature(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Creature:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Creature from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Creature.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Creature.model_validate({
+        _obj = cls.model_validate({
             "info": CreatureInfo.from_dict(obj.get("info")) if obj.get("info") is not None else None,
             "type": obj.get("type")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
@@ -20,6 +20,11 @@ import json
 
 
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class CreatureInfo(BaseModel):
     """
@@ -44,7 +49,7 @@ class CreatureInfo(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> CreatureInfo:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of CreatureInfo from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -57,15 +62,15 @@ class CreatureInfo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> CreatureInfo:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of CreatureInfo from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return CreatureInfo.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = CreatureInfo.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
@@ -21,6 +21,11 @@ import json
 
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DanishPig(BaseModel):
     """
@@ -46,7 +51,7 @@ class DanishPig(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DanishPig:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DanishPig from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class DanishPig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DanishPig:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DanishPig from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DanishPig.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DanishPig.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "size": obj.get("size")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DeprecatedObject(BaseModel):
     """
@@ -44,7 +49,7 @@ class DeprecatedObject(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DeprecatedObject:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DeprecatedObject from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -57,15 +62,15 @@ class DeprecatedObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DeprecatedObject:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DeprecatedObject from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DeprecatedObject.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DeprecatedObject.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import StrictStr
 from petstore_api.models.animal import Animal
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Dog(Animal):
     """
@@ -45,7 +50,7 @@ class Dog(Animal):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Dog:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Dog from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class Dog(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Dog:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Dog from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Dog.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Dog.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "color": obj.get("color") if obj.get("color") is not None else 'red',
             "breed": obj.get("breed")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DummyModel(BaseModel):
     """
@@ -45,7 +50,7 @@ class DummyModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DummyModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DummyModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class DummyModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DummyModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DummyModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DummyModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DummyModel.model_validate({
+        _obj = cls.model_validate({
             "category": obj.get("category"),
             "self_ref": SelfReferenceModel.from_dict(obj.get("self_ref")) if obj.get("self_ref") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
@@ -20,6 +20,11 @@ import json
 
 from typing import List, Optional
 from pydantic import BaseModel, StrictStr, field_validator
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class EnumArrays(BaseModel):
     """
@@ -66,7 +71,7 @@ class EnumArrays(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumArrays:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumArrays from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -79,15 +84,15 @@ class EnumArrays(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> EnumArrays:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of EnumArrays from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return EnumArrays.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = EnumArrays.model_validate({
+        _obj = cls.model_validate({
             "just_symbol": obj.get("just_symbol"),
             "array_enum": obj.get("array_enum")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_class.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class EnumClass(str, Enum):
@@ -34,8 +38,8 @@ class EnumClass(str, Enum):
     LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS = '(xyz)'
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumClass from a JSON string"""
-        return EnumClass(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string1.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string1.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class EnumString1(str, Enum):
@@ -33,8 +37,8 @@ class EnumString1(str, Enum):
     B = 'b'
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumString1:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumString1 from a JSON string"""
-        return EnumString1(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string2.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string2.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class EnumString2(str, Enum):
@@ -33,8 +37,8 @@ class EnumString2(str, Enum):
     D = 'd'
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumString2:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumString2 from a JSON string"""
-        return EnumString2(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -25,6 +25,11 @@ from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_default_value import OuterEnumDefaultValue
 from petstore_api.models.outer_enum_integer import OuterEnumInteger
 from petstore_api.models.outer_enum_integer_default_value import OuterEnumIntegerDefaultValue
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class EnumTest(BaseModel):
     """
@@ -104,7 +109,7 @@ class EnumTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -122,15 +127,15 @@ class EnumTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> EnumTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of EnumTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return EnumTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = EnumTest.model_validate({
+        _obj = cls.model_validate({
             "enum_string": obj.get("enum_string"),
             "enum_string_required": obj.get("enum_string_required"),
             "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class File(BaseModel):
     """
@@ -45,7 +50,7 @@ class File(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> File:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of File from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class File(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> File:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of File from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return File.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = File.model_validate({
+        _obj = cls.model_validate({
             "sourceURI": obj.get("sourceURI")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -21,6 +21,11 @@ import json
 from typing import List, Optional
 from pydantic import BaseModel
 from petstore_api.models.file import File
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FileSchemaTestClass(BaseModel):
     """
@@ -46,7 +51,7 @@ class FileSchemaTestClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FileSchemaTestClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FileSchemaTestClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -69,15 +74,15 @@ class FileSchemaTestClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FileSchemaTestClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FileSchemaTestClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FileSchemaTestClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FileSchemaTestClass.model_validate({
+        _obj = cls.model_validate({
             "file": File.from_dict(obj.get("file")) if obj.get("file") is not None else None,
             "files": [File.from_dict(_item) for _item in obj.get("files")] if obj.get("files") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FirstRef(BaseModel):
     """
@@ -45,7 +50,7 @@ class FirstRef(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FirstRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FirstRef from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class FirstRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FirstRef:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FirstRef from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FirstRef.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FirstRef.model_validate({
+        _obj = cls.model_validate({
             "category": obj.get("category"),
             "self_ref": SecondRef.from_dict(obj.get("self_ref")) if obj.get("self_ref") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Foo(BaseModel):
     """
@@ -44,7 +49,7 @@ class Foo(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Foo:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Foo from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -57,15 +62,15 @@ class Foo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Foo:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Foo from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Foo.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Foo.model_validate({
+        _obj = cls.model_validate({
             "bar": obj.get("bar") if obj.get("bar") is not None else 'bar'
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel
 from petstore_api.models.foo import Foo
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FooGetDefaultResponse(BaseModel):
     """
@@ -45,7 +50,7 @@ class FooGetDefaultResponse(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FooGetDefaultResponse:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FooGetDefaultResponse from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class FooGetDefaultResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FooGetDefaultResponse:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FooGetDefaultResponse from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FooGetDefaultResponse.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FooGetDefaultResponse.model_validate({
+        _obj = cls.model_validate({
             "string": Foo.from_dict(obj.get("string")) if obj.get("string") is not None else None
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -23,6 +23,11 @@ from pydantic import BaseModel, StrictBytes, StrictInt, StrictStr, field_validat
 from decimal import Decimal
 from pydantic import Field
 from typing_extensions import Annotated
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FormatTest(BaseModel):
     """
@@ -102,7 +107,7 @@ class FormatTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FormatTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FormatTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -115,15 +120,15 @@ class FormatTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FormatTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FormatTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FormatTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FormatTest.model_validate({
+        _obj = cls.model_validate({
             "integer": obj.get("integer"),
             "int32": obj.get("int32"),
             "int64": obj.get("int64"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class HasOnlyReadOnly(BaseModel):
     """
@@ -45,7 +50,7 @@ class HasOnlyReadOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> HasOnlyReadOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of HasOnlyReadOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -60,15 +65,15 @@ class HasOnlyReadOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> HasOnlyReadOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of HasOnlyReadOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return HasOnlyReadOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = HasOnlyReadOnly.model_validate({
+        _obj = cls.model_validate({
             "bar": obj.get("bar"),
             "foo": obj.get("foo")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class HealthCheckResult(BaseModel):
     """
@@ -45,7 +50,7 @@ class HealthCheckResult(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> HealthCheckResult:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of HealthCheckResult from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -63,15 +68,15 @@ class HealthCheckResult(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> HealthCheckResult:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of HealthCheckResult from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return HealthCheckResult.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = HealthCheckResult.model_validate({
+        _obj = cls.model_validate({
             "NullableMessage": obj.get("NullableMessage")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional, Union
 from pydantic import BaseModel
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class InnerDictWithProperty(BaseModel):
     """
@@ -45,7 +50,7 @@ class InnerDictWithProperty(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> InnerDictWithProperty:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of InnerDictWithProperty from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class InnerDictWithProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> InnerDictWithProperty:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of InnerDictWithProperty from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return InnerDictWithProperty.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = InnerDictWithProperty.model_validate({
+        _obj = cls.model_validate({
             "aProperty": obj.get("aProperty")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
@@ -25,6 +25,10 @@ from typing_extensions import Annotated
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 INTORSTRING_ONE_OF_SCHEMAS = ["int", "str"]
 
@@ -81,13 +85,13 @@ class IntOrString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> IntOrString:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> IntOrString:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = IntOrString.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         match = 0
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class List(BaseModel):
     """
@@ -45,7 +50,7 @@ class List(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> List:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of List from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class List(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> List:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of List from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return List.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = List.model_validate({
+        _obj = cls.model_validate({
             "123-list": obj.get("123-list")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -22,6 +22,11 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class MapOfArrayOfModel(BaseModel):
     """
@@ -46,7 +51,7 @@ class MapOfArrayOfModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> MapOfArrayOfModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of MapOfArrayOfModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class MapOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> MapOfArrayOfModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of MapOfArrayOfModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return MapOfArrayOfModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = MapOfArrayOfModel.model_validate({
+        _obj = cls.model_validate({
             "shopIdToOrgOnlineLipMap": dict(
                 (_k,
                         [Tag.from_dict(_item) for _item in _v]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Dict, Optional
 from pydantic import BaseModel, StrictBool, StrictStr, field_validator
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class MapTest(BaseModel):
     """
@@ -57,7 +62,7 @@ class MapTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> MapTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of MapTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -70,15 +75,15 @@ class MapTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> MapTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of MapTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return MapTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = MapTest.model_validate({
+        _obj = cls.model_validate({
             "map_map_of_string": obj.get("map_map_of_string"),
             "map_of_enum_string": obj.get("map_of_enum_string"),
             "direct_map": obj.get("direct_map"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -22,6 +22,11 @@ from typing import Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.animal import Animal
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     """
@@ -48,7 +53,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> MixedPropertiesAndAdditionalPropertiesClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of MixedPropertiesAndAdditionalPropertiesClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> MixedPropertiesAndAdditionalPropertiesClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of MixedPropertiesAndAdditionalPropertiesClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return MixedPropertiesAndAdditionalPropertiesClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = MixedPropertiesAndAdditionalPropertiesClass.model_validate({
+        _obj = cls.model_validate({
             "uuid": obj.get("uuid"),
             "dateTime": obj.get("dateTime"),
             "map": dict(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Model200Response(BaseModel):
     """
@@ -46,7 +51,7 @@ class Model200Response(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Model200Response:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Model200Response from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class Model200Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Model200Response:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Model200Response from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Model200Response.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Model200Response.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name"),
             "class": obj.get("class")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictInt
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ModelReturn(BaseModel):
     """
@@ -45,7 +50,7 @@ class ModelReturn(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ModelReturn:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ModelReturn from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class ModelReturn(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ModelReturn:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ModelReturn from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ModelReturn.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ModelReturn.model_validate({
+        _obj = cls.model_validate({
             "return": obj.get("return")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Name(BaseModel):
     """
@@ -48,7 +53,7 @@ class Name(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Name:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Name from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -63,15 +68,15 @@ class Name(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Name:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Name from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Name.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Name.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name"),
             "snake_case": obj.get("snake_case"),
             "property": obj.get("property"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -20,6 +20,11 @@ import json
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, StrictBool, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NullableClass(BaseModel):
     """
@@ -57,7 +62,7 @@ class NullableClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NullableClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NullableClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -131,15 +136,15 @@ class NullableClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NullableClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NullableClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NullableClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NullableClass.model_validate({
+        _obj = cls.model_validate({
             "required_integer_prop": obj.get("required_integer_prop"),
             "integer_prop": obj.get("integer_prop"),
             "number_prop": obj.get("number_prop"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -22,6 +22,11 @@ from typing import Optional
 from pydantic import BaseModel, StrictInt, field_validator
 from pydantic import Field
 from typing_extensions import Annotated
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NullableProperty(BaseModel):
     """
@@ -57,7 +62,7 @@ class NullableProperty(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NullableProperty:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NullableProperty from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -75,15 +80,15 @@ class NullableProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NullableProperty:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NullableProperty from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NullableProperty.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NullableProperty.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NumberOnly(BaseModel):
     """
@@ -45,7 +50,7 @@ class NumberOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NumberOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NumberOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class NumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NumberOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NumberOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NumberOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NumberOnly.model_validate({
+        _obj = cls.model_validate({
             "JustNumber": obj.get("JustNumber")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictBool
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ObjectToTestAdditionalProperties(BaseModel):
     """
@@ -45,7 +50,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ObjectToTestAdditionalProperties:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ObjectToTestAdditionalProperties from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class ObjectToTestAdditionalProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ObjectToTestAdditionalProperties:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ObjectToTestAdditionalProperties from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ObjectToTestAdditionalProperties.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ObjectToTestAdditionalProperties.model_validate({
+        _obj = cls.model_validate({
             "property": obj.get("property") if obj.get("property") is not None else False
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -22,6 +22,11 @@ from typing import List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.deprecated_object import DeprecatedObject
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ObjectWithDeprecatedFields(BaseModel):
     """
@@ -49,7 +54,7 @@ class ObjectWithDeprecatedFields(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ObjectWithDeprecatedFields:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ObjectWithDeprecatedFields from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class ObjectWithDeprecatedFields(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ObjectWithDeprecatedFields:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ObjectWithDeprecatedFields from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ObjectWithDeprecatedFields.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ObjectWithDeprecatedFields.model_validate({
+        _obj = cls.model_validate({
             "uuid": obj.get("uuid"),
             "id": obj.get("id"),
             "deprecatedRef": DeprecatedObject.from_dict(obj.get("deprecatedRef")) if obj.get("deprecatedRef") is not None else None,

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
@@ -25,6 +25,10 @@ from petstore_api.models.enum_string2 import EnumString2
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 ONEOFENUMSTRING_ONE_OF_SCHEMAS = ["EnumString1", "EnumString2"]
 
@@ -79,13 +83,13 @@ class OneOfEnumString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> OneOfEnumString:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> OneOfEnumString:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = OneOfEnumString.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         match = 0
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
@@ -21,6 +21,11 @@ from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel, StrictBool, StrictInt, StrictStr, field_validator
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Order(BaseModel):
     """
@@ -60,7 +65,7 @@ class Order(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Order:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Order from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -73,15 +78,15 @@ class Order(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Order:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Order from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Order.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Order.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "petId": obj.get("petId"),
             "quantity": obj.get("quantity"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictBool, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class OuterComposite(BaseModel):
     """
@@ -46,7 +51,7 @@ class OuterComposite(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterComposite:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterComposite from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class OuterComposite(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> OuterComposite:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of OuterComposite from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return OuterComposite.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = OuterComposite.model_validate({
+        _obj = cls.model_validate({
             "my_number": obj.get("my_number"),
             "my_string": obj.get("my_string"),
             "my_boolean": obj.get("my_boolean")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnum(str, Enum):
@@ -34,8 +38,8 @@ class OuterEnum(str, Enum):
     DELIVERED = 'delivered'
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnum:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnum from a JSON string"""
-        return OuterEnum(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_default_value.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnumDefaultValue(str, Enum):
@@ -34,8 +38,8 @@ class OuterEnumDefaultValue(str, Enum):
     DELIVERED = 'delivered'
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnumDefaultValue:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnumDefaultValue from a JSON string"""
-        return OuterEnumDefaultValue(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnumInteger(int, Enum):
@@ -34,8 +38,8 @@ class OuterEnumInteger(int, Enum):
     NUMBER_2 = 2
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnumInteger:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnumInteger from a JSON string"""
-        return OuterEnumInteger(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnumIntegerDefaultValue(int, Enum):
@@ -35,8 +39,8 @@ class OuterEnumIntegerDefaultValue(int, Enum):
     NUMBER_2 = 2
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnumIntegerDefaultValue:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnumIntegerDefaultValue from a JSON string"""
-        return OuterEnumIntegerDefaultValue(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -22,6 +22,11 @@ from typing import Optional
 from pydantic import BaseModel
 from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_integer import OuterEnumInteger
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class OuterObjectWithEnumProperty(BaseModel):
     """
@@ -47,7 +52,7 @@ class OuterObjectWithEnumProperty(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterObjectWithEnumProperty:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterObjectWithEnumProperty from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class OuterObjectWithEnumProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> OuterObjectWithEnumProperty:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of OuterObjectWithEnumProperty from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return OuterObjectWithEnumProperty.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = OuterObjectWithEnumProperty.model_validate({
+        _obj = cls.model_validate({
             "str_value": obj.get("str_value"),
             "value": obj.get("value")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -22,6 +22,11 @@ from typing import Dict, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.inner_dict_with_property import InnerDictWithProperty
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Parent(BaseModel):
     """
@@ -46,7 +51,7 @@ class Parent(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Parent:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Parent from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class Parent(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Parent:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Parent from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Parent.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Parent.model_validate({
+        _obj = cls.model_validate({
             "optionalDict": dict(
                 (_k, InnerDictWithProperty.from_dict(_v))
                 for _k, _v in obj.get("optionalDict").items()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -22,6 +22,11 @@ from typing import Dict, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.inner_dict_with_property import InnerDictWithProperty
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ParentWithOptionalDict(BaseModel):
     """
@@ -46,7 +51,7 @@ class ParentWithOptionalDict(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ParentWithOptionalDict:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ParentWithOptionalDict from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class ParentWithOptionalDict(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ParentWithOptionalDict:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ParentWithOptionalDict from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ParentWithOptionalDict.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ParentWithOptionalDict.model_validate({
+        _obj = cls.model_validate({
             "optionalDict": dict(
                 (_k, InnerDictWithProperty.from_dict(_v))
                 for _k, _v in obj.get("optionalDict").items()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -24,6 +24,11 @@ from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.category import Category
 from petstore_api.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Pet(BaseModel):
     """
@@ -63,7 +68,7 @@ class Pet(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Pet:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Pet from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -86,15 +91,15 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Pet:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Pet.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Pet.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "category": Category.from_dict(obj.get("category")) if obj.get("category") is not None else None,
             "name": obj.get("name"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
@@ -25,6 +25,10 @@ from petstore_api.models.danish_pig import DanishPig
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 PIG_ONE_OF_SCHEMAS = ["BasquePig", "DanishPig"]
 
@@ -82,13 +86,13 @@ class Pig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Pig:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> Pig:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = Pig.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         match = 0
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class PropertyNameCollision(BaseModel):
     """
@@ -47,7 +52,7 @@ class PropertyNameCollision(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> PropertyNameCollision:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of PropertyNameCollision from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -60,15 +65,15 @@ class PropertyNameCollision(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> PropertyNameCollision:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of PropertyNameCollision from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return PropertyNameCollision.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = PropertyNameCollision.model_validate({
+        _obj = cls.model_validate({
             "_type": obj.get("_type"),
             "type": obj.get("type"),
             "type_": obj.get("type_")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ReadOnlyFirst(BaseModel):
     """
@@ -45,7 +50,7 @@ class ReadOnlyFirst(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ReadOnlyFirst:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ReadOnlyFirst from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -59,15 +64,15 @@ class ReadOnlyFirst(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ReadOnlyFirst:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ReadOnlyFirst from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ReadOnlyFirst.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ReadOnlyFirst.model_validate({
+        _obj = cls.model_validate({
             "bar": obj.get("bar"),
             "baz": obj.get("baz")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SecondRef(BaseModel):
     """
@@ -45,7 +50,7 @@ class SecondRef(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SecondRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SecondRef from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class SecondRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SecondRef:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SecondRef from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SecondRef.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SecondRef.model_validate({
+        _obj = cls.model_validate({
             "category": obj.get("category"),
             "circular_ref": CircularReferenceModel.from_dict(obj.get("circular_ref")) if obj.get("circular_ref") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SelfReferenceModel(BaseModel):
     """
@@ -45,7 +50,7 @@ class SelfReferenceModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SelfReferenceModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SelfReferenceModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -61,15 +66,15 @@ class SelfReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SelfReferenceModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SelfReferenceModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SelfReferenceModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SelfReferenceModel.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "nested": DummyModel.from_dict(obj.get("nested")) if obj.get("nested") is not None else None
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/single_ref_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/single_ref_type.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class SingleRefType(str, Enum):
@@ -33,8 +37,8 @@ class SingleRefType(str, Enum):
     USER = 'user'
 
     @classmethod
-    def from_json(cls, json_str: str) -> SingleRefType:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SingleRefType from a JSON string"""
-        return SingleRefType(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_character_enum.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_character_enum.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class SpecialCharacterEnum(str, Enum):
@@ -41,8 +45,8 @@ class SpecialCharacterEnum(str, Enum):
     HELLO_WORLD = ' hello world '
 
     @classmethod
-    def from_json(cls, json_str: str) -> SpecialCharacterEnum:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SpecialCharacterEnum from a JSON string"""
-        return SpecialCharacterEnum(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictInt
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SpecialModelName(BaseModel):
     """
@@ -45,7 +50,7 @@ class SpecialModelName(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SpecialModelName:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SpecialModelName from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class SpecialModelName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SpecialModelName:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SpecialModelName from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SpecialModelName.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SpecialModelName.model_validate({
+        _obj = cls.model_validate({
             "$special[property.name]": obj.get("$special[property.name]")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
@@ -22,6 +22,11 @@ from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from petstore_api.models.category import Category
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SpecialName(BaseModel):
     """
@@ -58,7 +63,7 @@ class SpecialName(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SpecialName:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SpecialName from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -74,15 +79,15 @@ class SpecialName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SpecialName:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SpecialName from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SpecialName.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SpecialName.model_validate({
+        _obj = cls.model_validate({
             "property": obj.get("property"),
             "async": Category.from_dict(obj.get("async")) if obj.get("async") is not None else None,
             "schema": obj.get("schema")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Tag(BaseModel):
     """
@@ -45,7 +50,7 @@ class Tag(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Tag:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Tag from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -58,15 +63,15 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Tag:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Tag.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Tag.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name")
         })

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
     """
@@ -46,7 +51,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> TestInlineFreeformAdditionalPropertiesRequest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of TestInlineFreeformAdditionalPropertiesRequest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> TestInlineFreeformAdditionalPropertiesRequest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of TestInlineFreeformAdditionalPropertiesRequest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return TestInlineFreeformAdditionalPropertiesRequest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = TestInlineFreeformAdditionalPropertiesRequest.model_validate({
+        _obj = cls.model_validate({
             "someProperty": obj.get("someProperty")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Tiger(BaseModel):
     """
@@ -44,7 +49,7 @@ class Tiger(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Tiger:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Tiger from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -57,15 +62,15 @@ class Tiger(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Tiger:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Tiger from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Tiger.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Tiger.model_validate({
+        _obj = cls.model_validate({
             "skill": obj.get("skill")
         })
         return _obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
@@ -21,6 +21,11 @@ import json
 from typing import Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class User(BaseModel):
     """
@@ -52,7 +57,7 @@ class User(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> User:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of User from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class User(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> User:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of User from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return User.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = User.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "username": obj.get("username"),
             "firstName": obj.get("firstName"),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -22,6 +22,11 @@ from typing import Optional
 from pydantic import BaseModel, StrictInt
 from petstore_api.models.one_of_enum_string import OneOfEnumString
 from petstore_api.models.pig import Pig
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class WithNestedOneOf(BaseModel):
     """
@@ -48,7 +53,7 @@ class WithNestedOneOf(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> WithNestedOneOf:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of WithNestedOneOf from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -67,15 +72,15 @@ class WithNestedOneOf(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> WithNestedOneOf:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of WithNestedOneOf from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return WithNestedOneOf.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = WithNestedOneOf.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "nested_pig": Pig.from_dict(obj.get("nested_pig")) if obj.get("nested_pig") is not None else None,
             "nested_oneof_enum_string": OneOfEnumString.from_dict(obj.get("nested_oneof_enum_string")) if obj.get("nested_oneof_enum_string") is not None else None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesAnyType(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesAnyType(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesAnyType:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesAnyType from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class AdditionalPropertiesAnyType(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesAnyType:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesAnyType from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesAnyType.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesAnyType.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesClass(BaseModel):
     """
@@ -46,7 +51,7 @@ class AdditionalPropertiesClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class AdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesClass.model_validate({
+        _obj = cls.model_validate({
             "map_property": obj.get("map_property"),
             "map_of_map_property": obj.get("map_of_map_property")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesObject(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesObject(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesObject:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesObject from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class AdditionalPropertiesObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesObject:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesObject from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesObject.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesObject.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AdditionalPropertiesWithDescriptionOnly(BaseModel):
     """
@@ -45,7 +50,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AdditionalPropertiesWithDescriptionOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AdditionalPropertiesWithDescriptionOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AdditionalPropertiesWithDescriptionOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AdditionalPropertiesWithDescriptionOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AdditionalPropertiesWithDescriptionOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AdditionalPropertiesWithDescriptionOnly.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.single_ref_type import SingleRefType
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class AllOfWithSingleRef(BaseModel):
     """
@@ -48,7 +53,7 @@ class AllOfWithSingleRef(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> AllOfWithSingleRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of AllOfWithSingleRef from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -67,15 +72,15 @@ class AllOfWithSingleRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AllOfWithSingleRef:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of AllOfWithSingleRef from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return AllOfWithSingleRef.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = AllOfWithSingleRef.model_validate({
+        _obj = cls.model_validate({
             "username": obj.get("username"),
             "SingleRefType": obj.get("SingleRefType")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional, Union
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Animal(BaseModel):
     """
@@ -65,7 +70,7 @@ class Animal(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Union(Cat, Dog):
+    def from_json(cls, json_str: str) -> Union[Self, Self]:
         """Create an instance of Animal from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -84,7 +89,7 @@ class Animal(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Union(Cat, Dog):
+    def from_dict(cls, obj: dict) -> Union[Self, Self]:
         """Create an instance of Animal from a dict"""
         # look up the object type based on discriminator mapping
         object_type = cls.get_discriminator_value(obj)

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
@@ -25,6 +25,10 @@ from typing_extensions import Annotated
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 ANYOFCOLOR_ANY_OF_SCHEMAS = ["List[int]", "str"]
 
@@ -88,13 +92,13 @@ class AnyOfColor(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AnyOfColor:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> AnyOfColor:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = AnyOfColor.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         # deserialize data into List[int]
         try:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
@@ -25,6 +25,10 @@ from petstore_api.models.danish_pig import DanishPig
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 ANYOFPIG_ANY_OF_SCHEMAS = ["BasquePig", "DanishPig"]
 
@@ -80,13 +84,13 @@ class AnyOfPig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> AnyOfPig:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> AnyOfPig:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = AnyOfPig.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         # anyof_schema_1_validator: Optional[BasquePig] = None
         try:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/api_response.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ApiResponse(BaseModel):
     """
@@ -47,7 +52,7 @@ class ApiResponse(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ApiResponse:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ApiResponse from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class ApiResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ApiResponse:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ApiResponse from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ApiResponse.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ApiResponse.model_validate({
+        _obj = cls.model_validate({
             "code": obj.get("code"),
             "type": obj.get("type"),
             "message": obj.get("message")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 from petstore_api.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayOfArrayOfModel(BaseModel):
     """
@@ -46,7 +51,7 @@ class ArrayOfArrayOfModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayOfArrayOfModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayOfArrayOfModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -74,15 +79,15 @@ class ArrayOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayOfArrayOfModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayOfArrayOfModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayOfArrayOfModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayOfArrayOfModel.model_validate({
+        _obj = cls.model_validate({
             "another_property": [
                     [Tag.from_dict(_inner_item) for _inner_item in _item]
                     for _item in obj.get("another_property")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, StrictFloat
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayOfArrayOfNumberOnly(BaseModel):
     """
@@ -46,7 +51,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayOfArrayOfNumberOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayOfArrayOfNumberOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayOfArrayOfNumberOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayOfArrayOfNumberOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayOfArrayOfNumberOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayOfArrayOfNumberOnly.model_validate({
+        _obj = cls.model_validate({
             "ArrayArrayNumber": obj.get("ArrayArrayNumber")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, StrictFloat
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayOfNumberOnly(BaseModel):
     """
@@ -46,7 +51,7 @@ class ArrayOfNumberOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayOfNumberOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayOfNumberOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class ArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayOfNumberOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayOfNumberOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayOfNumberOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayOfNumberOnly.model_validate({
+        _obj = cls.model_validate({
             "ArrayNumber": obj.get("ArrayNumber")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -23,6 +23,11 @@ from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.read_only_first import ReadOnlyFirst
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ArrayTest(BaseModel):
     """
@@ -50,7 +55,7 @@ class ArrayTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ArrayTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ArrayTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -78,15 +83,15 @@ class ArrayTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ArrayTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ArrayTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ArrayTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ArrayTest.model_validate({
+        _obj = cls.model_validate({
             "array_of_string": obj.get("array_of_string"),
             "array_array_of_integer": obj.get("array_array_of_integer"),
             "array_array_of_model": [

--- a/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class BasquePig(BaseModel):
     """
@@ -47,7 +52,7 @@ class BasquePig(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> BasquePig:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of BasquePig from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class BasquePig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> BasquePig:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of BasquePig from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return BasquePig.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = BasquePig.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "color": obj.get("color")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Capitalization(BaseModel):
     """
@@ -51,7 +56,7 @@ class Capitalization(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Capitalization:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Capitalization from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -70,15 +75,15 @@ class Capitalization(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Capitalization:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Capitalization from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Capitalization.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Capitalization.model_validate({
+        _obj = cls.model_validate({
             "smallCamel": obj.get("smallCamel"),
             "CapitalCamel": obj.get("CapitalCamel"),
             "small_Snake": obj.get("small_Snake"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import StrictBool
 from petstore_api.models.animal import Animal
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Cat(Animal):
     """
@@ -46,7 +51,7 @@ class Cat(Animal):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Cat:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Cat from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class Cat(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Cat:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Cat from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Cat.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Cat.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "color": obj.get("color") if obj.get("color") is not None else 'red',
             "declawed": obj.get("declawed")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/category.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Category(BaseModel):
     """
@@ -46,7 +51,7 @@ class Category(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Category:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Category from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Category:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Category.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Category.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name") if obj.get("name") is not None else 'default-name'
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class CircularReferenceModel(BaseModel):
     """
@@ -46,7 +51,7 @@ class CircularReferenceModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> CircularReferenceModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of CircularReferenceModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class CircularReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> CircularReferenceModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of CircularReferenceModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return CircularReferenceModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = CircularReferenceModel.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "nested": FirstRef.from_dict(obj.get("nested")) if obj.get("nested") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ClassModel(BaseModel):
     """
@@ -46,7 +51,7 @@ class ClassModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ClassModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ClassModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class ClassModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ClassModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ClassModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ClassModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ClassModel.model_validate({
+        _obj = cls.model_validate({
             "_class": obj.get("_class")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/client.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Client(BaseModel):
     """
@@ -45,7 +50,7 @@ class Client(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Client:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Client from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class Client(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Client:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Client from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Client.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Client.model_validate({
+        _obj = cls.model_validate({
             "client": obj.get("client")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/color.py
@@ -25,6 +25,10 @@ from typing_extensions import Annotated
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 COLOR_ONE_OF_SCHEMAS = ["List[int]", "str"]
 
@@ -92,13 +96,13 @@ class Color(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Color:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> Color:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = Color.model_construct()
+        instance = cls.model_construct()
         if json_str is None:
             return instance
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict
 from pydantic import BaseModel, StrictStr
 from petstore_api.models.creature_info import CreatureInfo
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Creature(BaseModel):
     """
@@ -47,7 +52,7 @@ class Creature(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Creature:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Creature from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -69,15 +74,15 @@ class Creature(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Creature:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Creature from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Creature.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Creature.model_validate({
+        _obj = cls.model_validate({
             "info": CreatureInfo.from_dict(obj.get("info")) if obj.get("info") is not None else None,
             "type": obj.get("type")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class CreatureInfo(BaseModel):
     """
@@ -45,7 +50,7 @@ class CreatureInfo(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> CreatureInfo:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of CreatureInfo from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class CreatureInfo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> CreatureInfo:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of CreatureInfo from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return CreatureInfo.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = CreatureInfo.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DanishPig(BaseModel):
     """
@@ -47,7 +52,7 @@ class DanishPig(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DanishPig:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DanishPig from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class DanishPig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DanishPig:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DanishPig from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DanishPig.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DanishPig.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "size": obj.get("size")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DeprecatedObject(BaseModel):
     """
@@ -45,7 +50,7 @@ class DeprecatedObject(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DeprecatedObject:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DeprecatedObject from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class DeprecatedObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DeprecatedObject:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DeprecatedObject from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DeprecatedObject.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DeprecatedObject.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import StrictStr
 from petstore_api.models.animal import Animal
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Dog(Animal):
     """
@@ -46,7 +51,7 @@ class Dog(Animal):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Dog:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Dog from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class Dog(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Dog:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Dog from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Dog.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Dog.model_validate({
+        _obj = cls.model_validate({
             "className": obj.get("className"),
             "color": obj.get("color") if obj.get("color") is not None else 'red',
             "breed": obj.get("breed")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class DummyModel(BaseModel):
     """
@@ -46,7 +51,7 @@ class DummyModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> DummyModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of DummyModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class DummyModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> DummyModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of DummyModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return DummyModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = DummyModel.model_validate({
+        _obj = cls.model_validate({
             "category": obj.get("category"),
             "self_ref": SelfReferenceModel.from_dict(obj.get("self_ref")) if obj.get("self_ref") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, StrictStr, field_validator
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class EnumArrays(BaseModel):
     """
@@ -67,7 +72,7 @@ class EnumArrays(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumArrays:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumArrays from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -86,15 +91,15 @@ class EnumArrays(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> EnumArrays:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of EnumArrays from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return EnumArrays.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = EnumArrays.model_validate({
+        _obj = cls.model_validate({
             "just_symbol": obj.get("just_symbol"),
             "array_enum": obj.get("array_enum")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class EnumClass(str, Enum):
@@ -34,8 +38,8 @@ class EnumClass(str, Enum):
     LEFT_PARENTHESIS_XYZ_RIGHT_PARENTHESIS = '(xyz)'
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumClass from a JSON string"""
-        return EnumClass(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_string1.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_string1.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class EnumString1(str, Enum):
@@ -33,8 +37,8 @@ class EnumString1(str, Enum):
     B = 'b'
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumString1:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumString1 from a JSON string"""
-        return EnumString1(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_string2.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_string2.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class EnumString2(str, Enum):
@@ -33,8 +37,8 @@ class EnumString2(str, Enum):
     D = 'd'
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumString2:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumString2 from a JSON string"""
-        return EnumString2(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -25,6 +25,11 @@ from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_default_value import OuterEnumDefaultValue
 from petstore_api.models.outer_enum_integer import OuterEnumInteger
 from petstore_api.models.outer_enum_integer_default_value import OuterEnumIntegerDefaultValue
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class EnumTest(BaseModel):
     """
@@ -105,7 +110,7 @@ class EnumTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> EnumTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of EnumTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -129,15 +134,15 @@ class EnumTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> EnumTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of EnumTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return EnumTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = EnumTest.model_validate({
+        _obj = cls.model_validate({
             "enum_string": obj.get("enum_string"),
             "enum_string_required": obj.get("enum_string_required"),
             "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class File(BaseModel):
     """
@@ -46,7 +51,7 @@ class File(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> File:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of File from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class File(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> File:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of File from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return File.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = File.model_validate({
+        _obj = cls.model_validate({
             "sourceURI": obj.get("sourceURI")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 from petstore_api.models.file import File
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FileSchemaTestClass(BaseModel):
     """
@@ -47,7 +52,7 @@ class FileSchemaTestClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FileSchemaTestClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FileSchemaTestClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -76,15 +81,15 @@ class FileSchemaTestClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FileSchemaTestClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FileSchemaTestClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FileSchemaTestClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FileSchemaTestClass.model_validate({
+        _obj = cls.model_validate({
             "file": File.from_dict(obj.get("file")) if obj.get("file") is not None else None,
             "files": [File.from_dict(_item) for _item in obj.get("files")] if obj.get("files") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FirstRef(BaseModel):
     """
@@ -46,7 +51,7 @@ class FirstRef(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FirstRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FirstRef from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class FirstRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FirstRef:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FirstRef from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FirstRef.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FirstRef.model_validate({
+        _obj = cls.model_validate({
             "category": obj.get("category"),
             "self_ref": SecondRef.from_dict(obj.get("self_ref")) if obj.get("self_ref") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Foo(BaseModel):
     """
@@ -45,7 +50,7 @@ class Foo(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Foo:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Foo from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class Foo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Foo:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Foo from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Foo.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Foo.model_validate({
+        _obj = cls.model_validate({
             "bar": obj.get("bar") if obj.get("bar") is not None else 'bar'
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from petstore_api.models.foo import Foo
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FooGetDefaultResponse(BaseModel):
     """
@@ -46,7 +51,7 @@ class FooGetDefaultResponse(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FooGetDefaultResponse:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FooGetDefaultResponse from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class FooGetDefaultResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FooGetDefaultResponse:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FooGetDefaultResponse from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FooGetDefaultResponse.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FooGetDefaultResponse.model_validate({
+        _obj = cls.model_validate({
             "string": Foo.from_dict(obj.get("string")) if obj.get("string") is not None else None
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -23,6 +23,11 @@ from pydantic import BaseModel, StrictBytes, StrictInt, StrictStr, field_validat
 from decimal import Decimal
 from pydantic import Field
 from typing_extensions import Annotated
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class FormatTest(BaseModel):
     """
@@ -103,7 +108,7 @@ class FormatTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> FormatTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of FormatTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -122,15 +127,15 @@ class FormatTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> FormatTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of FormatTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return FormatTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = FormatTest.model_validate({
+        _obj = cls.model_validate({
             "integer": obj.get("integer"),
             "int32": obj.get("int32"),
             "int64": obj.get("int64"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class HasOnlyReadOnly(BaseModel):
     """
@@ -46,7 +51,7 @@ class HasOnlyReadOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> HasOnlyReadOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of HasOnlyReadOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -67,15 +72,15 @@ class HasOnlyReadOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> HasOnlyReadOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of HasOnlyReadOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return HasOnlyReadOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = HasOnlyReadOnly.model_validate({
+        _obj = cls.model_validate({
             "bar": obj.get("bar"),
             "foo": obj.get("foo")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class HealthCheckResult(BaseModel):
     """
@@ -46,7 +51,7 @@ class HealthCheckResult(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> HealthCheckResult:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of HealthCheckResult from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -70,15 +75,15 @@ class HealthCheckResult(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> HealthCheckResult:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of HealthCheckResult from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return HealthCheckResult.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = HealthCheckResult.model_validate({
+        _obj = cls.model_validate({
             "NullableMessage": obj.get("NullableMessage")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional, Union
 from pydantic import BaseModel
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class InnerDictWithProperty(BaseModel):
     """
@@ -46,7 +51,7 @@ class InnerDictWithProperty(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> InnerDictWithProperty:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of InnerDictWithProperty from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class InnerDictWithProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> InnerDictWithProperty:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of InnerDictWithProperty from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return InnerDictWithProperty.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = InnerDictWithProperty.model_validate({
+        _obj = cls.model_validate({
             "aProperty": obj.get("aProperty")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
@@ -25,6 +25,10 @@ from typing_extensions import Annotated
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 INTORSTRING_ONE_OF_SCHEMAS = ["int", "str"]
 
@@ -81,13 +85,13 @@ class IntOrString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> IntOrString:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> IntOrString:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = IntOrString.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         match = 0
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/list.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class List(BaseModel):
     """
@@ -46,7 +51,7 @@ class List(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> List:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of List from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class List(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> List:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of List from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return List.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = List.model_validate({
+        _obj = cls.model_validate({
             "123-list": obj.get("123-list")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class MapOfArrayOfModel(BaseModel):
     """
@@ -47,7 +52,7 @@ class MapOfArrayOfModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> MapOfArrayOfModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of MapOfArrayOfModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -75,15 +80,15 @@ class MapOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> MapOfArrayOfModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of MapOfArrayOfModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return MapOfArrayOfModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = MapOfArrayOfModel.model_validate({
+        _obj = cls.model_validate({
             "shopIdToOrgOnlineLipMap": dict(
                 (_k,
                         [Tag.from_dict(_item) for _item in _v]

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictBool, StrictStr, field_validator
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class MapTest(BaseModel):
     """
@@ -58,7 +63,7 @@ class MapTest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> MapTest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of MapTest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -77,15 +82,15 @@ class MapTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> MapTest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of MapTest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return MapTest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = MapTest.model_validate({
+        _obj = cls.model_validate({
             "map_map_of_string": obj.get("map_map_of_string"),
             "map_of_enum_string": obj.get("map_of_enum_string"),
             "direct_map": obj.get("direct_map"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.animal import Animal
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     """
@@ -49,7 +54,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> MixedPropertiesAndAdditionalPropertiesClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of MixedPropertiesAndAdditionalPropertiesClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -75,15 +80,15 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> MixedPropertiesAndAdditionalPropertiesClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of MixedPropertiesAndAdditionalPropertiesClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return MixedPropertiesAndAdditionalPropertiesClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = MixedPropertiesAndAdditionalPropertiesClass.model_validate({
+        _obj = cls.model_validate({
             "uuid": obj.get("uuid"),
             "dateTime": obj.get("dateTime"),
             "map": dict(

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Model200Response(BaseModel):
     """
@@ -47,7 +52,7 @@ class Model200Response(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Model200Response:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Model200Response from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class Model200Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Model200Response:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Model200Response from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Model200Response.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Model200Response.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name"),
             "class": obj.get("class")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ModelReturn(BaseModel):
     """
@@ -46,7 +51,7 @@ class ModelReturn(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ModelReturn:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ModelReturn from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class ModelReturn(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ModelReturn:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ModelReturn from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ModelReturn.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ModelReturn.model_validate({
+        _obj = cls.model_validate({
             "return": obj.get("return")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/name.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Name(BaseModel):
     """
@@ -49,7 +54,7 @@ class Name(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Name:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Name from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -70,15 +75,15 @@ class Name(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Name:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Name from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Name.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Name.model_validate({
+        _obj = cls.model_validate({
             "name": obj.get("name"),
             "snake_case": obj.get("snake_case"),
             "property": obj.get("property"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -20,6 +20,11 @@ import json
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NullableClass(BaseModel):
     """
@@ -57,7 +62,7 @@ class NullableClass(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NullableClass:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NullableClass from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -131,15 +136,15 @@ class NullableClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NullableClass:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NullableClass from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NullableClass.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NullableClass.model_validate({
+        _obj = cls.model_validate({
             "required_integer_prop": obj.get("required_integer_prop"),
             "integer_prop": obj.get("integer_prop"),
             "number_prop": obj.get("number_prop"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, field_validator
 from pydantic import Field
 from typing_extensions import Annotated
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NullableProperty(BaseModel):
     """
@@ -58,7 +63,7 @@ class NullableProperty(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NullableProperty:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NullableProperty from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -82,15 +87,15 @@ class NullableProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NullableProperty:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NullableProperty from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NullableProperty.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NullableProperty.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictFloat
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class NumberOnly(BaseModel):
     """
@@ -46,7 +51,7 @@ class NumberOnly(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> NumberOnly:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of NumberOnly from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class NumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> NumberOnly:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of NumberOnly from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return NumberOnly.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = NumberOnly.model_validate({
+        _obj = cls.model_validate({
             "JustNumber": obj.get("JustNumber")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictBool
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ObjectToTestAdditionalProperties(BaseModel):
     """
@@ -46,7 +51,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ObjectToTestAdditionalProperties:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ObjectToTestAdditionalProperties from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class ObjectToTestAdditionalProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ObjectToTestAdditionalProperties:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ObjectToTestAdditionalProperties from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ObjectToTestAdditionalProperties.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ObjectToTestAdditionalProperties.model_validate({
+        _obj = cls.model_validate({
             "property": obj.get("property") if obj.get("property") is not None else False
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, StrictFloat, StrictStr
 from pydantic import Field
 from petstore_api.models.deprecated_object import DeprecatedObject
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ObjectWithDeprecatedFields(BaseModel):
     """
@@ -50,7 +55,7 @@ class ObjectWithDeprecatedFields(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ObjectWithDeprecatedFields:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ObjectWithDeprecatedFields from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -72,15 +77,15 @@ class ObjectWithDeprecatedFields(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ObjectWithDeprecatedFields:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ObjectWithDeprecatedFields from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ObjectWithDeprecatedFields.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ObjectWithDeprecatedFields.model_validate({
+        _obj = cls.model_validate({
             "uuid": obj.get("uuid"),
             "id": obj.get("id"),
             "deprecatedRef": DeprecatedObject.from_dict(obj.get("deprecatedRef")) if obj.get("deprecatedRef") is not None else None,

--- a/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
@@ -25,6 +25,10 @@ from petstore_api.models.enum_string2 import EnumString2
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 ONEOFENUMSTRING_ONE_OF_SCHEMAS = ["EnumString1", "EnumString2"]
 
@@ -79,13 +83,13 @@ class OneOfEnumString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> OneOfEnumString:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> OneOfEnumString:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = OneOfEnumString.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         match = 0
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/order.py
@@ -21,6 +21,11 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictBool, StrictInt, StrictStr, field_validator
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Order(BaseModel):
     """
@@ -61,7 +66,7 @@ class Order(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Order:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Order from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -80,15 +85,15 @@ class Order(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Order:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Order from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Order.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Order.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "petId": obj.get("petId"),
             "quantity": obj.get("quantity"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictBool, StrictFloat, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class OuterComposite(BaseModel):
     """
@@ -47,7 +52,7 @@ class OuterComposite(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterComposite:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterComposite from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class OuterComposite(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> OuterComposite:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of OuterComposite from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return OuterComposite.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = OuterComposite.model_validate({
+        _obj = cls.model_validate({
             "my_number": obj.get("my_number"),
             "my_string": obj.get("my_string"),
             "my_boolean": obj.get("my_boolean")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnum(str, Enum):
@@ -34,8 +38,8 @@ class OuterEnum(str, Enum):
     DELIVERED = 'delivered'
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnum:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnum from a JSON string"""
-        return OuterEnum(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnumDefaultValue(str, Enum):
@@ -34,8 +38,8 @@ class OuterEnumDefaultValue(str, Enum):
     DELIVERED = 'delivered'
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnumDefaultValue:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnumDefaultValue from a JSON string"""
-        return OuterEnumDefaultValue(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnumInteger(int, Enum):
@@ -34,8 +38,8 @@ class OuterEnumInteger(int, Enum):
     NUMBER_2 = 2
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnumInteger:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnumInteger from a JSON string"""
-        return OuterEnumInteger(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class OuterEnumIntegerDefaultValue(int, Enum):
@@ -35,8 +39,8 @@ class OuterEnumIntegerDefaultValue(int, Enum):
     NUMBER_2 = 2
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterEnumIntegerDefaultValue:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterEnumIntegerDefaultValue from a JSON string"""
-        return OuterEnumIntegerDefaultValue(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_integer import OuterEnumInteger
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class OuterObjectWithEnumProperty(BaseModel):
     """
@@ -48,7 +53,7 @@ class OuterObjectWithEnumProperty(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> OuterObjectWithEnumProperty:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of OuterObjectWithEnumProperty from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -72,15 +77,15 @@ class OuterObjectWithEnumProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> OuterObjectWithEnumProperty:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of OuterObjectWithEnumProperty from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return OuterObjectWithEnumProperty.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = OuterObjectWithEnumProperty.model_validate({
+        _obj = cls.model_validate({
             "str_value": obj.get("str_value"),
             "value": obj.get("value")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.inner_dict_with_property import InnerDictWithProperty
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Parent(BaseModel):
     """
@@ -47,7 +52,7 @@ class Parent(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Parent:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Parent from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -73,15 +78,15 @@ class Parent(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Parent:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Parent from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Parent.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Parent.model_validate({
+        _obj = cls.model_validate({
             "optionalDict": dict(
                 (_k, InnerDictWithProperty.from_dict(_v))
                 for _k, _v in obj.get("optionalDict").items()

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.inner_dict_with_property import InnerDictWithProperty
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ParentWithOptionalDict(BaseModel):
     """
@@ -47,7 +52,7 @@ class ParentWithOptionalDict(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ParentWithOptionalDict:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ParentWithOptionalDict from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -73,15 +78,15 @@ class ParentWithOptionalDict(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ParentWithOptionalDict:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ParentWithOptionalDict from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ParentWithOptionalDict.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ParentWithOptionalDict.model_validate({
+        _obj = cls.model_validate({
             "optionalDict": dict(
                 (_k, InnerDictWithProperty.from_dict(_v))
                 for _k, _v in obj.get("optionalDict").items()

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
@@ -24,6 +24,11 @@ from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.category import Category
 from petstore_api.models.tag import Tag
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Pet(BaseModel):
     """
@@ -64,7 +69,7 @@ class Pet(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Pet:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Pet from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -93,15 +98,15 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Pet:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Pet.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Pet.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "category": Category.from_dict(obj.get("category")) if obj.get("category") is not None else None,
             "name": obj.get("name"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
@@ -25,6 +25,10 @@ from petstore_api.models.danish_pig import DanishPig
 from typing import Union, Any, List, TYPE_CHECKING, Optional, Dict
 from typing_extensions import Literal
 from pydantic import StrictStr, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 PIG_ONE_OF_SCHEMAS = ["BasquePig", "DanishPig"]
 
@@ -82,13 +86,13 @@ class Pig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Pig:
+    def from_dict(cls, obj: dict) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> Pig:
+    def from_json(cls, json_str: str) -> Self:
         """Returns the object represented by the json string"""
-        instance = Pig.model_construct()
+        instance = cls.model_construct()
         error_messages = []
         match = 0
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class PropertyNameCollision(BaseModel):
     """
@@ -48,7 +53,7 @@ class PropertyNameCollision(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> PropertyNameCollision:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of PropertyNameCollision from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -67,15 +72,15 @@ class PropertyNameCollision(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> PropertyNameCollision:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of PropertyNameCollision from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return PropertyNameCollision.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = PropertyNameCollision.model_validate({
+        _obj = cls.model_validate({
             "_type": obj.get("_type"),
             "type": obj.get("type"),
             "type_": obj.get("type_")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class ReadOnlyFirst(BaseModel):
     """
@@ -46,7 +51,7 @@ class ReadOnlyFirst(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> ReadOnlyFirst:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of ReadOnlyFirst from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -66,15 +71,15 @@ class ReadOnlyFirst(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> ReadOnlyFirst:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of ReadOnlyFirst from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return ReadOnlyFirst.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = ReadOnlyFirst.model_validate({
+        _obj = cls.model_validate({
             "bar": obj.get("bar"),
             "baz": obj.get("baz")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SecondRef(BaseModel):
     """
@@ -46,7 +51,7 @@ class SecondRef(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SecondRef:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SecondRef from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class SecondRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SecondRef:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SecondRef from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SecondRef.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SecondRef.model_validate({
+        _obj = cls.model_validate({
             "category": obj.get("category"),
             "circular_ref": CircularReferenceModel.from_dict(obj.get("circular_ref")) if obj.get("circular_ref") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SelfReferenceModel(BaseModel):
     """
@@ -46,7 +51,7 @@ class SelfReferenceModel(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SelfReferenceModel:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SelfReferenceModel from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -68,15 +73,15 @@ class SelfReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SelfReferenceModel:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SelfReferenceModel from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SelfReferenceModel.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SelfReferenceModel.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "nested": DummyModel.from_dict(obj.get("nested")) if obj.get("nested") is not None else None
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/single_ref_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/single_ref_type.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class SingleRefType(str, Enum):
@@ -33,8 +37,8 @@ class SingleRefType(str, Enum):
     USER = 'user'
 
     @classmethod
-    def from_json(cls, json_str: str) -> SingleRefType:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SingleRefType from a JSON string"""
-        return SingleRefType(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_character_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_character_enum.py
@@ -19,6 +19,10 @@ from aenum import Enum, no_arg
 
 
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class SpecialCharacterEnum(str, Enum):
@@ -41,8 +45,8 @@ class SpecialCharacterEnum(str, Enum):
     HELLO_WORLD = ' hello world '
 
     @classmethod
-    def from_json(cls, json_str: str) -> SpecialCharacterEnum:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SpecialCharacterEnum from a JSON string"""
-        return SpecialCharacterEnum(json.loads(json_str))
+        return cls(json.loads(json_str))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SpecialModelName(BaseModel):
     """
@@ -46,7 +51,7 @@ class SpecialModelName(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SpecialModelName:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SpecialModelName from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class SpecialModelName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SpecialModelName:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SpecialModelName from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SpecialModelName.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SpecialModelName.model_validate({
+        _obj = cls.model_validate({
             "$special[property.name]": obj.get("$special[property.name]")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from petstore_api.models.category import Category
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class SpecialName(BaseModel):
     """
@@ -59,7 +64,7 @@ class SpecialName(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> SpecialName:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of SpecialName from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -81,15 +86,15 @@ class SpecialName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> SpecialName:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of SpecialName from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return SpecialName.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = SpecialName.model_validate({
+        _obj = cls.model_validate({
             "property": obj.get("property"),
             "async": Category.from_dict(obj.get("async")) if obj.get("async") is not None else None,
             "schema": obj.get("schema")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Tag(BaseModel):
     """
@@ -46,7 +51,7 @@ class Tag(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Tag:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Tag from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Tag:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Tag.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Tag.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "name": obj.get("name")
         })

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
     """
@@ -46,7 +51,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> TestInlineFreeformAdditionalPropertiesRequest:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of TestInlineFreeformAdditionalPropertiesRequest from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -65,15 +70,15 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> TestInlineFreeformAdditionalPropertiesRequest:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of TestInlineFreeformAdditionalPropertiesRequest from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return TestInlineFreeformAdditionalPropertiesRequest.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = TestInlineFreeformAdditionalPropertiesRequest.model_validate({
+        _obj = cls.model_validate({
             "someProperty": obj.get("someProperty")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
@@ -20,6 +20,11 @@ import json
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictStr
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class Tiger(BaseModel):
     """
@@ -45,7 +50,7 @@ class Tiger(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> Tiger:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of Tiger from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -64,15 +69,15 @@ class Tiger(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Tiger:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of Tiger from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return Tiger.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = Tiger.model_validate({
+        _obj = cls.model_validate({
             "skill": obj.get("skill")
         })
         # store additional fields in additional_properties

--- a/samples/openapi3/client/petstore/python/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/user.py
@@ -21,6 +21,11 @@ import json
 from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class User(BaseModel):
     """
@@ -53,7 +58,7 @@ class User(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> User:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of User from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -72,15 +77,15 @@ class User(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> User:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of User from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return User.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = User.model_validate({
+        _obj = cls.model_validate({
             "id": obj.get("id"),
             "username": obj.get("username"),
             "firstName": obj.get("firstName"),

--- a/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
@@ -22,6 +22,11 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, StrictInt
 from petstore_api.models.one_of_enum_string import OneOfEnumString
 from petstore_api.models.pig import Pig
+from typing import Dict, Any
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 class WithNestedOneOf(BaseModel):
     """
@@ -49,7 +54,7 @@ class WithNestedOneOf(BaseModel):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_str: str) -> WithNestedOneOf:
+    def from_json(cls, json_str: str) -> Self:
         """Create an instance of WithNestedOneOf from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
@@ -74,15 +79,15 @@ class WithNestedOneOf(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: dict) -> WithNestedOneOf:
+    def from_dict(cls, obj: dict) -> Self:
         """Create an instance of WithNestedOneOf from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
-            return WithNestedOneOf.model_validate(obj)
+            return cls.model_validate(obj)
 
-        _obj = WithNestedOneOf.model_validate({
+        _obj = cls.model_validate({
             "size": obj.get("size"),
             "nested_pig": Pig.from_dict(obj.get("nested_pig")) if obj.get("nested_pig") is not None else None,
             "nested_oneof_enum_string": OneOfEnumString.from_dict(obj.get("nested_oneof_enum_string")) if obj.get("nested_oneof_enum_string") is not None else None


### PR DESCRIPTION
This doesn't offer a clear win but this helps for:

* Using modern types and making the typing intent clearer
* Decreasing the need for `from __future__ import annotations`, since a class can now refer to itself without using its name
* Using more `cls` to automatically refer to the class, instead of respecifying the class name every time

Self is available from Python 3.11 and is provided in typing_extensions (since 4.0.0) as a fallback for older versions

See: https://peps.python.org/pep-0673/
See: https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#added-in-version-400

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
