### PR TITLE
python: fix typing for API responses

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1256,6 +1256,9 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 // Not interested in the result, only in the update of the imports
                 getPydanticType(operation.returnProperty, typingImports,
                         new TreeSet<>() /* skip pydantic import for return type */, datetimeImports, modelImports, exampleImports, postponedModelImports, postponedExampleImports, null);
+                operation.vendorExtensions.put("x-py-return-type", operation.returnType);
+            } else {
+                operation.vendorExtensions.put("x-py-return-type", "None");
             }
 
             // add import for code samples

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -13,7 +13,6 @@ from pydantic import validate_call, ValidationError
 {{/imports}}
 
 from {{packageName}}.api_client import ApiClient
-from {{packageName}}.api_response import ApiResponse
 from {{packageName}}.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -36,10 +35,10 @@ class {{classname}}:
 
     @validate_call
 {{#asyncio}}
-    async def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
+    async def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{vendorExtensions.x-py-return-type}}}:  # noqa: E501
 {{/asyncio}}
 {{^asyncio}}
-    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
+    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{vendorExtensions.x-py-return-type}}}:  # noqa: E501
 {{/asyncio}}
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 
@@ -69,7 +68,7 @@ class {{classname}}:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: {{returnType}}{{^returnType}}None{{/returnType}}
+        :rtype: {{{vendorExtensions.x-py-return-type}}}
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
@@ -79,10 +78,10 @@ class {{classname}}:
 
     @validate_call
 {{#asyncio}}
-    async def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> ApiResponse:  # noqa: E501
+    async def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{vendorExtensions.x-py-return-type}}}:  # noqa: E501
 {{/asyncio}}
 {{^asyncio}}
-    def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> ApiResponse:  # noqa: E501
+    def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{vendorExtensions.x-py-return-type}}}:  # noqa: E501
 {{/asyncio}}
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 
@@ -125,7 +124,7 @@ class {{classname}}:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: {{#returnType}}tuple({{.}}, status_code(int), headers(HTTPHeaderDict)){{/returnType}}{{^returnType}}None{{/returnType}}
+        :rtype: {{{vendorExtensions.x-py-return-type}}}
         """
 
         {{#isDeprecated}}

--- a/samples/client/echo_api/python/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/auth_api.py
@@ -21,7 +21,6 @@ from pydantic import validate_call, ValidationError
 
 
 from openapi_client.api_client import ApiClient
-from openapi_client.api_response import ApiResponse
 from openapi_client.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -69,7 +68,7 @@ class AuthApi:
         return self.test_auth_http_basic_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def test_auth_http_basic_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_auth_http_basic_with_http_info(self, **kwargs) -> str:  # noqa: E501
         """To test HTTP basic authentication  # noqa: E501
 
         To test HTTP basic authentication  # noqa: E501
@@ -101,7 +100,7 @@ class AuthApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -29,7 +29,6 @@ from openapi_client.models.pet import Pet
 from openapi_client.models.tag import Tag
 
 from openapi_client.api_client import ApiClient
-from openapi_client.api_response import ApiResponse
 from openapi_client.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -77,7 +76,7 @@ class BodyApi:
         return self.test_binary_gif_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def test_binary_gif_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_binary_gif_with_http_info(self, **kwargs) -> bytearray:  # noqa: E501
         """Test binary (gif) response body  # noqa: E501
 
         Test binary (gif) response body  # noqa: E501
@@ -109,7 +108,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(bytearray, status_code(int), headers(HTTPHeaderDict))
+        :rtype: bytearray
         """
 
         _params = locals()
@@ -211,7 +210,7 @@ class BodyApi:
         return self.test_body_application_octetstream_binary_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_body_application_octetstream_binary_with_http_info(self, body : Optional[Union[StrictBytes, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_body_application_octetstream_binary_with_http_info(self, body : Optional[Union[StrictBytes, StrictStr]] = None, **kwargs) -> str:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
         Test body parameter(s)  # noqa: E501
@@ -245,7 +244,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -363,7 +362,7 @@ class BodyApi:
         return self.test_body_multipart_formdata_array_of_binary_with_http_info(files, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_body_multipart_formdata_array_of_binary_with_http_info(self, files : List[Union[StrictBytes, StrictStr]], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_body_multipart_formdata_array_of_binary_with_http_info(self, files : List[Union[StrictBytes, StrictStr]], **kwargs) -> str:  # noqa: E501
         """Test array of binary in multipart mime  # noqa: E501
 
         Test array of binary in multipart mime  # noqa: E501
@@ -397,7 +396,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -511,7 +510,7 @@ class BodyApi:
         return self.test_echo_body_free_form_object_response_string_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_echo_body_free_form_object_response_string_with_http_info(self, body : Annotated[Optional[Dict[str, Any]], Field(description="Free form object")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_echo_body_free_form_object_response_string_with_http_info(self, body : Annotated[Optional[Dict[str, Any]], Field(description="Free form object")] = None, **kwargs) -> str:  # noqa: E501
         """Test free form object  # noqa: E501
 
         Test free form object  # noqa: E501
@@ -545,7 +544,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -658,7 +657,7 @@ class BodyApi:
         return self.test_echo_body_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_echo_body_pet_with_http_info(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_echo_body_pet_with_http_info(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> Pet:  # noqa: E501
         """Test body parameter(s)  # noqa: E501
 
         Test body parameter(s)  # noqa: E501
@@ -692,7 +691,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Pet, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Pet
         """
 
         _params = locals()
@@ -805,7 +804,7 @@ class BodyApi:
         return self.test_echo_body_pet_response_string_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_echo_body_pet_response_string_with_http_info(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_echo_body_pet_response_string_with_http_info(self, pet : Annotated[Optional[Pet], Field(description="Pet object that needs to be added to the store")] = None, **kwargs) -> str:  # noqa: E501
         """Test empty response body  # noqa: E501
 
         Test empty response body  # noqa: E501
@@ -839,7 +838,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -952,7 +951,7 @@ class BodyApi:
         return self.test_echo_body_tag_response_string_with_http_info(tag, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_echo_body_tag_response_string_with_http_info(self, tag : Annotated[Optional[Tag], Field(description="Tag object")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_echo_body_tag_response_string_with_http_info(self, tag : Annotated[Optional[Tag], Field(description="Tag object")] = None, **kwargs) -> str:  # noqa: E501
         """Test empty json (request body)  # noqa: E501
 
         Test empty json (request body)  # noqa: E501
@@ -986,7 +985,7 @@ class BodyApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -25,7 +25,6 @@ from typing import Optional
 
 
 from openapi_client.api_client import ApiClient
-from openapi_client.api_response import ApiResponse
 from openapi_client.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -79,7 +78,7 @@ class FormApi:
         return self.test_form_integer_boolean_string_with_http_info(integer_form, boolean_form, string_form, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_form_integer_boolean_string_with_http_info(self, integer_form : Optional[StrictInt] = None, boolean_form : Optional[StrictBool] = None, string_form : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_form_integer_boolean_string_with_http_info(self, integer_form : Optional[StrictInt] = None, boolean_form : Optional[StrictBool] = None, string_form : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test form parameter(s)  # noqa: E501
 
         Test form parameter(s)  # noqa: E501
@@ -117,7 +116,7 @@ class FormApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -248,7 +247,7 @@ class FormApi:
         return self.test_form_oneof_with_http_info(form1, form2, form3, form4, id, name, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_form_oneof_with_http_info(self, form1 : Optional[StrictStr] = None, form2 : Optional[StrictInt] = None, form3 : Optional[StrictStr] = None, form4 : Optional[StrictBool] = None, id : Optional[StrictInt] = None, name : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_form_oneof_with_http_info(self, form1 : Optional[StrictStr] = None, form2 : Optional[StrictInt] = None, form3 : Optional[StrictStr] = None, form4 : Optional[StrictBool] = None, id : Optional[StrictInt] = None, name : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test form parameter(s) for oneOf schema  # noqa: E501
 
         Test form parameter(s) for oneOf schema  # noqa: E501
@@ -292,7 +291,7 @@ class FormApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -25,7 +25,6 @@ from typing import Optional
 
 
 from openapi_client.api_client import ApiClient
-from openapi_client.api_response import ApiResponse
 from openapi_client.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -79,7 +78,7 @@ class HeaderApi:
         return self.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_header_integer_boolean_string_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_header_integer_boolean_string_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
@@ -117,7 +116,7 @@ class HeaderApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -23,7 +23,6 @@ from pydantic import StrictInt, StrictStr
 
 
 from openapi_client.api_client import ApiClient
-from openapi_client.api_response import ApiResponse
 from openapi_client.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -75,7 +74,7 @@ class PathApi:
         return self.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, **kwargs)  # noqa: E501
 
     @validate_call
-    def tests_path_string_path_string_integer_path_integer_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> ApiResponse:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> str:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
@@ -111,7 +110,7 @@ class PathApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -30,7 +30,6 @@ from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.models.test_query_style_form_explode_true_array_string_query_object_parameter import TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 
 from openapi_client.api_client import ApiClient
-from openapi_client.api_response import ApiResponse
 from openapi_client.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -80,7 +79,7 @@ class QueryApi:
         return self.test_enum_ref_string_with_http_info(enum_ref_string_query, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_enum_ref_string_with_http_info(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_enum_ref_string_with_http_info(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -114,7 +113,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -224,7 +223,7 @@ class QueryApi:
         return self.test_query_datetime_date_string_with_http_info(datetime_query, date_query, string_query, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[datetime] = None, date_query : Optional[date] = None, string_query : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_datetime_date_string_with_http_info(self, datetime_query : Optional[datetime] = None, date_query : Optional[date] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -262,7 +261,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -386,7 +385,7 @@ class QueryApi:
         return self.test_query_integer_boolean_string_with_http_info(integer_query, boolean_query, string_query, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_integer_boolean_string_with_http_info(self, integer_query : Optional[StrictInt] = None, boolean_query : Optional[StrictBool] = None, string_query : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_integer_boolean_string_with_http_info(self, integer_query : Optional[StrictInt] = None, boolean_query : Optional[StrictBool] = None, string_query : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -424,7 +423,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -538,7 +537,7 @@ class QueryApi:
         return self.test_query_style_deep_object_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_style_deep_object_explode_true_object_with_http_info(self, query_object : Optional[Pet] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_style_deep_object_explode_true_object_with_http_info(self, query_object : Optional[Pet] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -572,7 +571,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -678,7 +677,7 @@ class QueryApi:
         return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_style_deep_object_explode_true_object_all_of_with_http_info(self, query_object : Optional[Any] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_style_deep_object_explode_true_object_all_of_with_http_info(self, query_object : Optional[Any] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -712,7 +711,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -818,7 +817,7 @@ class QueryApi:
         return self.test_query_style_form_explode_true_array_string_with_http_info(query_object, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_style_form_explode_true_array_string_with_http_info(self, query_object : Optional[TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_style_form_explode_true_array_string_with_http_info(self, query_object : Optional[TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -852,7 +851,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -958,7 +957,7 @@ class QueryApi:
         return self.test_query_style_form_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_style_form_explode_true_object_with_http_info(self, query_object : Optional[Pet] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_style_form_explode_true_object_with_http_info(self, query_object : Optional[Pet] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -992,7 +991,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -1098,7 +1097,7 @@ class QueryApi:
         return self.test_query_style_form_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_style_form_explode_true_object_all_of_with_http_info(self, query_object : Optional[Any] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_style_form_explode_true_object_all_of_with_http_info(self, query_object : Optional[Any] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
@@ -1132,7 +1131,7 @@ class QueryApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -23,7 +23,6 @@ from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -66,7 +65,7 @@ class AnotherFakeApi:
         return await self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_call
-    async def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test special tags  # noqa: E501
 
         To test special tags and operation ID starting with number  # noqa: E501
@@ -93,7 +92,7 @@ class AnotherFakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Client, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Client
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -21,7 +21,6 @@ from pydantic import validate_call, ValidationError
 from petstore_api.models.foo_get_default_response import FooGetDefaultResponse
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -61,7 +60,7 @@ class DefaultApi:
         return await self.foo_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    async def foo_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def foo_get_with_http_info(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
         """foo_get  # noqa: E501
 
 
@@ -85,7 +84,7 @@ class DefaultApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(FooGetDefaultResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: FooGetDefaultResponse
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -38,7 +38,6 @@ from petstore_api.models.test_inline_freeform_additional_properties_request impo
 from petstore_api.models.user import User
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -80,7 +79,7 @@ class FakeApi:
         return await self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> None:  # noqa: E501
         """test any type request body  # noqa: E501
 
 
@@ -203,7 +202,7 @@ class FakeApi:
         return await self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> None:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
 
@@ -317,7 +316,7 @@ class FakeApi:
         return await self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_health_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_health_get_with_http_info(self, **kwargs) -> HealthCheckResult:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
 
@@ -341,7 +340,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(HealthCheckResult, status_code(int), headers(HTTPHeaderDict))
+        :rtype: HealthCheckResult
         """
 
         _params = locals()
@@ -437,7 +436,7 @@ class FakeApi:
         return await self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
 
@@ -573,7 +572,7 @@ class FakeApi:
         return await self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
         Test serialization of outer boolean types  # noqa: E501
@@ -600,7 +599,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(bool, status_code(int), headers(HTTPHeaderDict))
+        :rtype: bool
         """
 
         _params = locals()
@@ -704,7 +703,7 @@ class FakeApi:
         return await self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
         Test serialization of object with outer number type  # noqa: E501
@@ -731,7 +730,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(OuterComposite, status_code(int), headers(HTTPHeaderDict))
+        :rtype: OuterComposite
         """
 
         _params = locals()
@@ -835,7 +834,7 @@ class FakeApi:
         return await self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
         Test serialization of outer number types  # noqa: E501
@@ -862,7 +861,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(float, status_code(int), headers(HTTPHeaderDict))
+        :rtype: float
         """
 
         _params = locals()
@@ -966,7 +965,7 @@ class FakeApi:
         return await self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
         Test serialization of outer string types  # noqa: E501
@@ -993,7 +992,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -1097,7 +1096,7 @@ class FakeApi:
         return await self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(description="Input enum (int) as post body")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
         Test serialization of enum (int) properties with examples  # noqa: E501
@@ -1124,7 +1123,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(OuterObjectWithEnumProperty, status_code(int), headers(HTTPHeaderDict))
+        :rtype: OuterObjectWithEnumProperty
         """
 
         _params = locals()
@@ -1225,7 +1224,7 @@ class FakeApi:
         return await self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_return_list_of_objects_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_return_list_of_objects_with_http_info(self, **kwargs) -> List[List[Tag]]:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
 
@@ -1249,7 +1248,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(List[List[Tag]], status_code(int), headers(HTTPHeaderDict))
+        :rtype: List[List[Tag]]
         """
 
         _params = locals()
@@ -1341,7 +1340,7 @@ class FakeApi:
         return await self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
 
     @validate_call
-    async def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(description="uuid example")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(description="uuid example")], **kwargs) -> None:  # noqa: E501
         """test uuid example  # noqa: E501
 
 
@@ -1458,7 +1457,7 @@ class FakeApi:
         return await self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="image to upload")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="image to upload")], **kwargs) -> None:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
         For this test, the body has to be a binary file.  # noqa: E501
@@ -1588,7 +1587,7 @@ class FakeApi:
         return await self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
         For this test, the body for this request must reference a schema named `File`.  # noqa: E501
@@ -1714,7 +1713,7 @@ class FakeApi:
         return await self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
 
@@ -1844,7 +1843,7 @@ class FakeApi:
         return await self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_client_model_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_client_model_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
         To test \"client\" model  # noqa: E501
@@ -1871,7 +1870,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Client, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Client
         """
 
         _params = locals()
@@ -1976,7 +1975,7 @@ class FakeApi:
         return await self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
 
@@ -2130,7 +2129,7 @@ class FakeApi:
         return await self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_endpoint_parameters_with_http_info(self, number : Annotated[float, Field(le=543.2, ge=32.1, description="None")], double : Annotated[float, Field(le=123.4, ge=67.8, description="None")], pattern_without_delimiter : Annotated[str, Field(strict=True, description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(description="None")], integer : Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=10)]], Field(description="None")] = None, int32 : Annotated[Optional[Annotated[int, Field(le=200, strict=True, ge=20)]], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[Annotated[float, Field(le=987.6)]], Field(description="None")] = None, string : Annotated[Optional[Annotated[str, Field(strict=True)]], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[Annotated[bytes, Field(strict=True, max_length=64)], Annotated[str, Field(strict=True, max_length=64)]]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[Annotated[str, Field(min_length=10, strict=True, max_length=64)]], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_endpoint_parameters_with_http_info(self, number : Annotated[float, Field(le=543.2, ge=32.1, description="None")], double : Annotated[float, Field(le=123.4, ge=67.8, description="None")], pattern_without_delimiter : Annotated[str, Field(strict=True, description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(description="None")], integer : Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=10)]], Field(description="None")] = None, int32 : Annotated[Optional[Annotated[int, Field(le=200, strict=True, ge=20)]], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[Annotated[float, Field(le=987.6)]], Field(description="None")] = None, string : Annotated[Optional[Annotated[str, Field(strict=True)]], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[Annotated[bytes, Field(strict=True, max_length=64)], Annotated[str, Field(strict=True, max_length=64)]]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[Annotated[str, Field(min_length=10, strict=True, max_length=64)]], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
@@ -2349,7 +2348,7 @@ class FakeApi:
         return await self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
         Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -2497,7 +2496,7 @@ class FakeApi:
         return await self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(description="request body")], **kwargs) -> None:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
           # noqa: E501
@@ -2622,7 +2621,7 @@ class FakeApi:
         return await self.test_inline_freeform_additional_properties_with_http_info(test_inline_freeform_additional_properties_request, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_inline_freeform_additional_properties_with_http_info(self, test_inline_freeform_additional_properties_request : Annotated[TestInlineFreeformAdditionalPropertiesRequest, Field(description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_inline_freeform_additional_properties_with_http_info(self, test_inline_freeform_additional_properties_request : Annotated[TestInlineFreeformAdditionalPropertiesRequest, Field(description="request body")], **kwargs) -> None:  # noqa: E501
         """test inline free-form additionalProperties  # noqa: E501
 
           # noqa: E501
@@ -2749,7 +2748,7 @@ class FakeApi:
         return await self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(description="field1")], param2 : Annotated[StrictStr, Field(description="field2")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(description="field1")], param2 : Annotated[StrictStr, Field(description="field2")], **kwargs) -> None:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
           # noqa: E501
@@ -2892,7 +2891,7 @@ class FakeApi:
         return await self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_query_parameter_collection_format_with_http_info(self, pipe : List[StrictStr], ioutil : List[StrictStr], http : List[StrictStr], url : List[StrictStr], context : List[StrictStr], allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_query_parameter_collection_format_with_http_info(self, pipe : List[StrictStr], ioutil : List[StrictStr], http : List[StrictStr], url : List[StrictStr], context : List[StrictStr], allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -23,7 +23,6 @@ from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -66,7 +65,7 @@ class FakeClassnameTags123Api:
         return await self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_call
-    async def test_classname_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_classname_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
         To test class name in snake case  # noqa: E501
@@ -93,7 +92,7 @@ class FakeClassnameTags123Api:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Client, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Client
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -28,7 +28,6 @@ from petstore_api.models.api_response import ApiResponse
 from petstore_api.models.pet import Pet
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -71,7 +70,7 @@ class PetApi:
         return await self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_call
-    async def add_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def add_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
           # noqa: E501
@@ -198,7 +197,7 @@ class PetApi:
         return await self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
 
     @validate_call
-    async def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
           # noqa: E501
@@ -322,7 +321,7 @@ class PetApi:
         return await self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
 
     @validate_call
-    async def find_pets_by_status_with_http_info(self, status : Annotated[List[StrictStr], Field(description="Status values that need to be considered for filter")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def find_pets_by_status_with_http_info(self, status : Annotated[List[StrictStr], Field(description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
         Multiple status values can be provided with comma separated strings  # noqa: E501
@@ -349,7 +348,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(List[Pet], status_code(int), headers(HTTPHeaderDict))
+        :rtype: List[Pet]
         """
 
         _params = locals()
@@ -448,7 +447,7 @@ class PetApi:
         return await self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
 
     @validate_call
-    async def find_pets_by_tags_with_http_info(self, tags : Annotated[List[StrictStr], Field(description="Tags to filter by")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def find_pets_by_tags_with_http_info(self, tags : Annotated[List[StrictStr], Field(description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.  # noqa: E501
@@ -475,7 +474,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(List[Pet], status_code(int), headers(HTTPHeaderDict))
+        :rtype: List[Pet]
         """
 
         warnings.warn("GET /pet/findByTags is deprecated.", DeprecationWarning)
@@ -576,7 +575,7 @@ class PetApi:
         return await self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
 
     @validate_call
-    async def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet to return")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
         Returns a single pet  # noqa: E501
@@ -603,7 +602,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Pet, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Pet
         """
 
         _params = locals()
@@ -702,7 +701,7 @@ class PetApi:
         return await self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_call
-    async def update_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def update_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
           # noqa: E501
@@ -831,7 +830,7 @@ class PetApi:
         return await self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
 
     @validate_call
-    async def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
           # noqa: E501
@@ -1003,7 +1002,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(ApiResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: ApiResponse
         """
 
         _params = locals()
@@ -1150,7 +1149,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(ApiResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: ApiResponse
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -27,7 +27,6 @@ from typing import Dict
 from petstore_api.models.order import Order
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -70,7 +69,7 @@ class StoreApi:
         return await self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_call
-    async def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(description="ID of the order that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors  # noqa: E501
@@ -186,7 +185,7 @@ class StoreApi:
         return await self.get_inventory_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    async def get_inventory_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_inventory_with_http_info(self, **kwargs) -> Dict[str, int]:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
         Returns a map of status codes to quantities  # noqa: E501
@@ -211,7 +210,7 @@ class StoreApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Dict[str, int], status_code(int), headers(HTTPHeaderDict))
+        :rtype: Dict[str, int]
         """
 
         _params = locals()
@@ -304,7 +303,7 @@ class StoreApi:
         return await self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_call
-    async def get_order_by_id_with_http_info(self, order_id : Annotated[int, Field(le=5, strict=True, ge=1, description="ID of pet that needs to be fetched")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_order_by_id_with_http_info(self, order_id : Annotated[int, Field(le=5, strict=True, ge=1, description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions  # noqa: E501
@@ -331,7 +330,7 @@ class StoreApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Order, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Order
         """
 
         _params = locals()
@@ -430,7 +429,7 @@ class StoreApi:
         return await self.place_order_with_http_info(order, **kwargs)  # noqa: E501
 
     @validate_call
-    async def place_order_with_http_info(self, order : Annotated[Order, Field(description="order placed for purchasing the pet")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def place_order_with_http_info(self, order : Annotated[Order, Field(description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
           # noqa: E501
@@ -457,7 +456,7 @@ class StoreApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Order, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Order
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -27,7 +27,6 @@ from typing import List
 from petstore_api.models.user import User
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -70,7 +69,7 @@ class UserApi:
         return await self.create_user_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_call
-    async def create_user_with_http_info(self, user : Annotated[User, Field(description="Created user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def create_user_with_http_info(self, user : Annotated[User, Field(description="Created user object")], **kwargs) -> None:  # noqa: E501
         """Create user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -210,7 +209,7 @@ class UserApi:
         return await self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_call
-    async def create_users_with_array_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def create_users_with_array_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
@@ -335,7 +334,7 @@ class UserApi:
         return await self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_call
-    async def create_users_with_list_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def create_users_with_list_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
@@ -460,7 +459,7 @@ class UserApi:
         return await self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_call
-    async def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -578,7 +577,7 @@ class UserApi:
         return await self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_call
-    async def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
         """Get user by user name  # noqa: E501
 
           # noqa: E501
@@ -605,7 +604,7 @@ class UserApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(User, status_code(int), headers(HTTPHeaderDict))
+        :rtype: User
         """
 
         _params = locals()
@@ -706,7 +705,7 @@ class UserApi:
         return await self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
 
     @validate_call
-    async def login_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The user name for login")], password : Annotated[StrictStr, Field(description="The password for login in clear text")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def login_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The user name for login")], password : Annotated[StrictStr, Field(description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
           # noqa: E501
@@ -735,7 +734,7 @@ class UserApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -835,7 +834,7 @@ class UserApi:
         return await self.logout_user_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    async def logout_user_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def logout_user_with_http_info(self, **kwargs) -> None:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
           # noqa: E501
@@ -949,7 +948,7 @@ class UserApi:
         return await self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
 
     @validate_call
-    async def update_user_with_http_info(self, username : Annotated[StrictStr, Field(description="name that need to be deleted")], user : Annotated[User, Field(description="Updated user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def update_user_with_http_info(self, username : Annotated[StrictStr, Field(description="name that need to be deleted")], user : Annotated[User, Field(description="Updated user object")], **kwargs) -> None:  # noqa: E501
         """Updated user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -23,7 +23,6 @@ from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -73,7 +72,7 @@ class AnotherFakeApi:
         return self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_call
-    def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test special tags  # noqa: E501
 
         To test special tags and operation ID starting with number  # noqa: E501
@@ -107,7 +106,7 @@ class AnotherFakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Client, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Client
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -21,7 +21,6 @@ from pydantic import validate_call, ValidationError
 from petstore_api.models.foo_get_default_response import FooGetDefaultResponse
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -68,7 +67,7 @@ class DefaultApi:
         return self.foo_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def foo_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def foo_get_with_http_info(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
         """foo_get  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -99,7 +98,7 @@ class DefaultApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(FooGetDefaultResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: FooGetDefaultResponse
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -38,7 +38,6 @@ from petstore_api.models.test_inline_freeform_additional_properties_request impo
 from petstore_api.models.user import User
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -87,7 +86,7 @@ class FakeApi:
         return self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> None:  # noqa: E501
         """test any type request body  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -226,7 +225,7 @@ class FakeApi:
         return self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> None:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -356,7 +355,7 @@ class FakeApi:
         return self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def fake_health_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_health_get_with_http_info(self, **kwargs) -> HealthCheckResult:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -387,7 +386,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(HealthCheckResult, status_code(int), headers(HTTPHeaderDict))
+        :rtype: HealthCheckResult
         """
 
         _params = locals()
@@ -492,7 +491,7 @@ class FakeApi:
         return self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -644,7 +643,7 @@ class FakeApi:
         return self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
         Test serialization of outer boolean types  # noqa: E501
@@ -678,7 +677,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(bool, status_code(int), headers(HTTPHeaderDict))
+        :rtype: bool
         """
 
         _params = locals()
@@ -791,7 +790,7 @@ class FakeApi:
         return self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
         Test serialization of object with outer number type  # noqa: E501
@@ -825,7 +824,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(OuterComposite, status_code(int), headers(HTTPHeaderDict))
+        :rtype: OuterComposite
         """
 
         _params = locals()
@@ -938,7 +937,7 @@ class FakeApi:
         return self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[StrictFloat], Field(description="Input number as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[StrictFloat], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
         Test serialization of outer number types  # noqa: E501
@@ -972,7 +971,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(float, status_code(int), headers(HTTPHeaderDict))
+        :rtype: float
         """
 
         _params = locals()
@@ -1085,7 +1084,7 @@ class FakeApi:
         return self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
         Test serialization of outer string types  # noqa: E501
@@ -1119,7 +1118,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -1232,7 +1231,7 @@ class FakeApi:
         return self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(description="Input enum (int) as post body")], **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
         Test serialization of enum (int) properties with examples  # noqa: E501
@@ -1266,7 +1265,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(OuterObjectWithEnumProperty, status_code(int), headers(HTTPHeaderDict))
+        :rtype: OuterObjectWithEnumProperty
         """
 
         _params = locals()
@@ -1376,7 +1375,7 @@ class FakeApi:
         return self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def fake_return_list_of_objects_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_return_list_of_objects_with_http_info(self, **kwargs) -> List[List[Tag]]:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -1407,7 +1406,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(List[List[Tag]], status_code(int), headers(HTTPHeaderDict))
+        :rtype: List[List[Tag]]
         """
 
         _params = locals()
@@ -1508,7 +1507,7 @@ class FakeApi:
         return self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
 
     @validate_call
-    def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(description="uuid example")], **kwargs) -> ApiResponse:  # noqa: E501
+    def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(description="uuid example")], **kwargs) -> None:  # noqa: E501
         """test uuid example  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -1641,7 +1640,7 @@ class FakeApi:
         return self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="image to upload")], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="image to upload")], **kwargs) -> None:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
         For this test, the body has to be a binary file.  # noqa: E501
@@ -1787,7 +1786,7 @@ class FakeApi:
         return self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
         For this test, the body for this request must reference a schema named `File`.  # noqa: E501
@@ -1929,7 +1928,7 @@ class FakeApi:
         return self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -2075,7 +2074,7 @@ class FakeApi:
         return self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_client_model_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_client_model_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
         To test \"client\" model  # noqa: E501
@@ -2109,7 +2108,7 @@ class FakeApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Client, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Client
         """
 
         _params = locals()
@@ -2223,7 +2222,7 @@ class FakeApi:
         return self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
@@ -2393,7 +2392,7 @@ class FakeApi:
         return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_endpoint_parameters_with_http_info(self, number : Annotated[float, Field(le=543.2, strict=True, ge=32.1, description="None")], double : Annotated[float, Field(le=123.4, strict=True, ge=67.8, description="None")], pattern_without_delimiter : Annotated[str, Field(strict=True, description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(description="None")], integer : Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=10)]], Field(description="None")] = None, int32 : Annotated[Optional[Annotated[int, Field(le=200, strict=True, ge=20)]], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[Annotated[float, Field(le=987.6, strict=True)]], Field(description="None")] = None, string : Annotated[Optional[Annotated[str, Field(strict=True)]], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[Annotated[bytes, Field(strict=True, max_length=64)], Annotated[str, Field(strict=True, max_length=64)]]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[Annotated[str, Field(min_length=10, strict=True, max_length=64)]], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_endpoint_parameters_with_http_info(self, number : Annotated[float, Field(le=543.2, strict=True, ge=32.1, description="None")], double : Annotated[float, Field(le=123.4, strict=True, ge=67.8, description="None")], pattern_without_delimiter : Annotated[str, Field(strict=True, description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(description="None")], integer : Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=10)]], Field(description="None")] = None, int32 : Annotated[Optional[Annotated[int, Field(le=200, strict=True, ge=20)]], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[Annotated[float, Field(le=987.6, strict=True)]], Field(description="None")] = None, string : Annotated[Optional[Annotated[str, Field(strict=True)]], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[Annotated[bytes, Field(strict=True, max_length=64)], Annotated[str, Field(strict=True, max_length=64)]]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[Annotated[str, Field(min_length=10, strict=True, max_length=64)]], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
@@ -2628,7 +2627,7 @@ class FakeApi:
         return self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
         Fake endpoint to test group parameters (optional)  # noqa: E501
@@ -2792,7 +2791,7 @@ class FakeApi:
         return self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(description="request body")], **kwargs) -> None:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
           # noqa: E501
@@ -2933,7 +2932,7 @@ class FakeApi:
         return self.test_inline_freeform_additional_properties_with_http_info(test_inline_freeform_additional_properties_request, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_inline_freeform_additional_properties_with_http_info(self, test_inline_freeform_additional_properties_request : Annotated[TestInlineFreeformAdditionalPropertiesRequest, Field(description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_inline_freeform_additional_properties_with_http_info(self, test_inline_freeform_additional_properties_request : Annotated[TestInlineFreeformAdditionalPropertiesRequest, Field(description="request body")], **kwargs) -> None:  # noqa: E501
         """test inline free-form additionalProperties  # noqa: E501
 
           # noqa: E501
@@ -3076,7 +3075,7 @@ class FakeApi:
         return self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(description="field1")], param2 : Annotated[StrictStr, Field(description="field2")], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(description="field1")], param2 : Annotated[StrictStr, Field(description="field2")], **kwargs) -> None:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
           # noqa: E501
@@ -3235,7 +3234,7 @@ class FakeApi:
         return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_query_parameter_collection_format_with_http_info(self, pipe : List[StrictStr], ioutil : List[StrictStr], http : List[StrictStr], url : List[StrictStr], context : List[StrictStr], allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_query_parameter_collection_format_with_http_info(self, pipe : List[StrictStr], ioutil : List[StrictStr], http : List[StrictStr], url : List[StrictStr], context : List[StrictStr], allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
@@ -23,7 +23,6 @@ from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -73,7 +72,7 @@ class FakeClassnameTags123Api:
         return self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_classname_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    def test_classname_with_http_info(self, client : Annotated[Client, Field(description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
         To test class name in snake case  # noqa: E501
@@ -107,7 +106,7 @@ class FakeClassnameTags123Api:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Client, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Client
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -28,7 +28,6 @@ from petstore_api.models.api_response import ApiResponse
 from petstore_api.models.pet import Pet
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -78,7 +77,7 @@ class PetApi:
         return self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_call
-    def add_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
+    def add_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
           # noqa: E501
@@ -221,7 +220,7 @@ class PetApi:
         return self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
 
     @validate_call
-    def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
           # noqa: E501
@@ -361,7 +360,7 @@ class PetApi:
         return self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
 
     @validate_call
-    def find_pets_by_status_with_http_info(self, status : Annotated[List[StrictStr], Field(description="Status values that need to be considered for filter")], **kwargs) -> ApiResponse:  # noqa: E501
+    def find_pets_by_status_with_http_info(self, status : Annotated[List[StrictStr], Field(description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
         Multiple status values can be provided with comma separated strings  # noqa: E501
@@ -395,7 +394,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(List[Pet], status_code(int), headers(HTTPHeaderDict))
+        :rtype: List[Pet]
         """
 
         _params = locals()
@@ -503,7 +502,7 @@ class PetApi:
         return self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
 
     @validate_call
-    def find_pets_by_tags_with_http_info(self, tags : Annotated[List[StrictStr], Field(description="Tags to filter by")], **kwargs) -> ApiResponse:  # noqa: E501
+    def find_pets_by_tags_with_http_info(self, tags : Annotated[List[StrictStr], Field(description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.  # noqa: E501
@@ -537,7 +536,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(List[Pet], status_code(int), headers(HTTPHeaderDict))
+        :rtype: List[Pet]
         """
 
         warnings.warn("GET /pet/findByTags is deprecated.", DeprecationWarning)
@@ -647,7 +646,7 @@ class PetApi:
         return self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
 
     @validate_call
-    def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet to return")], **kwargs) -> ApiResponse:  # noqa: E501
+    def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
         Returns a single pet  # noqa: E501
@@ -681,7 +680,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Pet, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Pet
         """
 
         _params = locals()
@@ -789,7 +788,7 @@ class PetApi:
         return self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_call
-    def update_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
+    def update_pet_with_http_info(self, pet : Annotated[Pet, Field(description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
           # noqa: E501
@@ -934,7 +933,7 @@ class PetApi:
         return self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
 
     @validate_call
-    def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
           # noqa: E501
@@ -1129,7 +1128,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(ApiResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: ApiResponse
         """
 
         _params = locals()
@@ -1292,7 +1291,7 @@ class PetApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(ApiResponse, status_code(int), headers(HTTPHeaderDict))
+        :rtype: ApiResponse
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -27,7 +27,6 @@ from typing import Dict
 from petstore_api.models.order import Order
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -77,7 +76,7 @@ class StoreApi:
         return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_call
-    def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(description="ID of the order that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors  # noqa: E501
@@ -209,7 +208,7 @@ class StoreApi:
         return self.get_inventory_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def get_inventory_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def get_inventory_with_http_info(self, **kwargs) -> Dict[str, int]:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
         Returns a map of status codes to quantities  # noqa: E501
@@ -241,7 +240,7 @@ class StoreApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Dict[str, int], status_code(int), headers(HTTPHeaderDict))
+        :rtype: Dict[str, int]
         """
 
         _params = locals()
@@ -343,7 +342,7 @@ class StoreApi:
         return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_call
-    def get_order_by_id_with_http_info(self, order_id : Annotated[int, Field(le=5, strict=True, ge=1, description="ID of pet that needs to be fetched")], **kwargs) -> ApiResponse:  # noqa: E501
+    def get_order_by_id_with_http_info(self, order_id : Annotated[int, Field(le=5, strict=True, ge=1, description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions  # noqa: E501
@@ -377,7 +376,7 @@ class StoreApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Order, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Order
         """
 
         _params = locals()
@@ -485,7 +484,7 @@ class StoreApi:
         return self.place_order_with_http_info(order, **kwargs)  # noqa: E501
 
     @validate_call
-    def place_order_with_http_info(self, order : Annotated[Order, Field(description="order placed for purchasing the pet")], **kwargs) -> ApiResponse:  # noqa: E501
+    def place_order_with_http_info(self, order : Annotated[Order, Field(description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
           # noqa: E501
@@ -519,7 +518,7 @@ class StoreApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(Order, status_code(int), headers(HTTPHeaderDict))
+        :rtype: Order
         """
 
         _params = locals()

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -27,7 +27,6 @@ from typing import List
 from petstore_api.models.user import User
 
 from petstore_api.api_client import ApiClient
-from petstore_api.api_response import ApiResponse
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
     ApiValueError
@@ -77,7 +76,7 @@ class UserApi:
         return self.create_user_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_call
-    def create_user_with_http_info(self, user : Annotated[User, Field(description="Created user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    def create_user_with_http_info(self, user : Annotated[User, Field(description="Created user object")], **kwargs) -> None:  # noqa: E501
         """Create user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -233,7 +232,7 @@ class UserApi:
         return self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_call
-    def create_users_with_array_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    def create_users_with_array_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
@@ -374,7 +373,7 @@ class UserApi:
         return self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_call
-    def create_users_with_list_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    def create_users_with_list_input_with_http_info(self, user : Annotated[List[User], Field(description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
@@ -515,7 +514,7 @@ class UserApi:
         return self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_call
-    def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
+    def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
@@ -649,7 +648,7 @@ class UserApi:
         return self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_call
-    def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> ApiResponse:  # noqa: E501
+    def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
         """Get user by user name  # noqa: E501
 
           # noqa: E501
@@ -683,7 +682,7 @@ class UserApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(User, status_code(int), headers(HTTPHeaderDict))
+        :rtype: User
         """
 
         _params = locals()
@@ -793,7 +792,7 @@ class UserApi:
         return self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
 
     @validate_call
-    def login_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The user name for login")], password : Annotated[StrictStr, Field(description="The password for login in clear text")], **kwargs) -> ApiResponse:  # noqa: E501
+    def login_user_with_http_info(self, username : Annotated[StrictStr, Field(description="The user name for login")], password : Annotated[StrictStr, Field(description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
           # noqa: E501
@@ -829,7 +828,7 @@ class UserApi:
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
-        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        :rtype: str
         """
 
         _params = locals()
@@ -938,7 +937,7 @@ class UserApi:
         return self.logout_user_with_http_info(**kwargs)  # noqa: E501
 
     @validate_call
-    def logout_user_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    def logout_user_with_http_info(self, **kwargs) -> None:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
           # noqa: E501
@@ -1068,7 +1067,7 @@ class UserApi:
         return self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
 
     @validate_call
-    def update_user_with_http_info(self, username : Annotated[StrictStr, Field(description="name that need to be deleted")], user : Annotated[User, Field(description="Updated user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    def update_user_with_http_info(self, username : Annotated[StrictStr, Field(description="name that need to be deleted")], user : Annotated[User, Field(description="Updated user object")], **kwargs) -> None:  # noqa: E501
         """Updated user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501


### PR DESCRIPTION
The `*_with_http_info` methods, instead of returning a generic ApiResponse object now return the actual object the method relates to.


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
